### PR TITLE
Fixed load cell-calibrate method and safety checks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ mypy:
 .PHONY: check-safety
 check-safety:
 	poetry check
-	poetry run safety check --full-report --ignore 67599
+	poetry run safety check --full-report --ignore 70612
 	poetry run bandit --recursive -c pyproject.toml opensourceleg tests
 
 .PHONY: lint

--- a/opensourceleg/hardware/sensors.py
+++ b/opensourceleg/hardware/sensors.py
@@ -19,7 +19,7 @@ This module defines classes related to load cell management, specifically for th
 Usage Guide:
 
 1. For load cell management, create an instance of `Loadcell` with appropriate parameters (e.g., dephy_mode, joint, amp_gain, exc, loadcell_matrix, logger).
-2. Optionally, initialize the load cell zero using the `initialize` method.
+2. Optionally, calibrate the load cell zero using the `calibrate` method.
 3. Update the load cell data using the `update` method.
 4. Access force and moment values using the properties like `fx`, `fy`, `fz`, `mx`, `my`, `mz`.
 5. For testing, use the mocked classes `MockStrainAmp` and `MockLoadcell` as needed.
@@ -151,8 +151,8 @@ class Loadcell:
         return f"Loadcell"
 
     def reset(self):
-        self._zeroed = False
         self._loadcell_zero = np.zeros(shape=(1, 6), dtype=np.double)
+        self._zeroed = False
 
     def update(self, loadcell_zero=None) -> None:
         """
@@ -188,7 +188,7 @@ class Loadcell:
                 - loadcell_zero
             )
 
-    def initialize(self, number_of_iterations: int = 2000) -> None:
+    def calibrate(self, number_of_iterations: int = 2000, reset=False) -> None:
         """
         Obtains the initial loadcell reading (aka) loadcell_zero.
         This is automatically subtraced off for subsequent calls of the update method.
@@ -223,14 +223,14 @@ class Loadcell:
             self._zeroed = True
             self._log.info(f"[{self.__repr__()}] Zeroing routine complete.")
 
-        elif (
-            input(
-                f"[{self.__repr__()}] Would you like to re-initialize loadcell? (y/n): "
-            )
-            == "y"
-        ):
+        elif reset:
             self.reset()
-            self.initialize()
+            self.calibrate()
+
+        else:
+            self._log.info(
+                f"[{self.__repr__()}] Loadcell has already been zeroed. To recalibrate, set reset=True in the calibrate method or call reset() first."
+            )
 
     @property
     def is_zeroed(self) -> bool:

--- a/opensourceleg/hardware/sensors.py
+++ b/opensourceleg/hardware/sensors.py
@@ -197,9 +197,8 @@ class Loadcell:
 
         if not self._zeroed:
             self._log.info(
-                f"[{self.__repr__()}] Initiating zeroing routine, please ensure that there is no ground contact force."
+                f"[{self.__repr__()}] Initiating zeroing routine, please ensure that there is no ground contact force.\n{input('Press any key to start.')}"
             )
-            time.sleep(1)
 
             if self._is_dephy:
                 if self._joint.is_streaming:

--- a/opensourceleg/osl.py
+++ b/opensourceleg/osl.py
@@ -76,7 +76,7 @@ class OpenSourceLeg:
             self._ankle.start()
 
         if self.has_loadcell:
-            self._loadcell.initialize()
+            self._loadcell.calibrate()
 
     def __exit__(self, type=None, value=None, tb=None) -> None:
 
@@ -365,13 +365,13 @@ class OpenSourceLeg:
 
         self._is_homed = True
 
-    def calibrate_loadcell(self) -> None:
-        self.log.debug(msg="[OSL] Calibrating loadcell.")
+    def calibrate_loadcell(self, reset=True) -> None:
         if self.has_loadcell:
-            self.loadcell.reset()
+            self.log.debug(msg="[OSL] Calibrating loadcell.")
+            self.loadcell.calibrate(reset=reset)
 
     def make_encoder_maps(self, overwrite=False) -> None:
-        self.log.debug(msg="[OSL] Calibrating encoders.")
+        self.log.debug(msg="[OSL] Making encoder maps.")
 
         if self.has_knee:
             self.knee.make_encoder_map(overwrite=overwrite)

--- a/tests/test_osl/test_opensourceleg.py
+++ b/tests/test_osl/test_opensourceleg.py
@@ -570,14 +570,13 @@ def test_osl_calibrate_loadcell(loadcell_patched: Loadcell):
 
     test_osl_cl = OpenSourceLeg()
     test_osl_cl.add_loadcell(loadcell_matrix=LOADCELL_MATRIX)
-    test_osl_cl._loadcell._zeroed = True
     test_osl_cl.log = Logger(file_path="tests/test_osl/test_osl_cl")
     test_osl_cl.log.set_stream_level("DEBUG")
     test_osl_cl.calibrate_loadcell()
     with open("tests/test_osl/test_osl_cl.log") as f:
         contents = f.read()
         assert "[OSL] Calibrating loadcell." in contents
-    assert test_osl_cl._loadcell._zeroed == False
+    assert test_osl_cl._loadcell._zeroed == True
 
 
 def test_osl_reset(joint_patched: Joint, mock_get_active_ports, patch_sleep):

--- a/tests/test_osl/test_opensourceleg.py
+++ b/tests/test_osl/test_opensourceleg.py
@@ -80,8 +80,17 @@ def test_opensourceleg_init(mock_time):
 #     assert OpenSourceLeg._instance == None
 
 
+@pytest.fixture
+def patch_input(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+
 def test_osl_enter(
-    mock_get_active_ports, joint_patched: Joint, loadcell_patched: Loadcell, patch_sleep
+    mock_get_active_ports,
+    joint_patched: Joint,
+    loadcell_patched: Loadcell,
+    patch_sleep,
+    patch_input,
 ):
     """
     Tests the OpenSourceLeg __enter__ method\n
@@ -559,7 +568,7 @@ def test_osl_home(joint_patched: Joint, mock_get_active_ports):
     assert test_osl_h._ankle._is_homed == True
 
 
-def test_osl_calibrate_loadcell(loadcell_patched: Loadcell):
+def test_osl_calibrate_loadcell(loadcell_patched: Loadcell, patch_input):
     """
     Tests the OpenSourceLeg calibrate_loadcell method\n
     Intializes an OpenSourceLeg object with a logger of the lowest stream level

--- a/tests/test_sensors/test_sensors.py
+++ b/tests/test_sensors/test_sensors.py
@@ -718,8 +718,8 @@ def test_loadcell_initialize(loadcell_patched: Loadcell, mocker, patch_sleep):
     lc_initialize._is_dephy = True
     lc_initialize._zeroed = True
     # Patch the input method to return "y" when running pytest
-    mocker.patch("builtins.input", return_value="y")
-    lc_initialize.initialize()
+    # mocker.patch("builtins.input", return_value="y")
+    lc_initialize.calibrate(reset=True)
     # Assert the proper log messages are written for the else statement in the if statement in the if statement
     with open("tests/test_sensors/test_loadcell_initialize_log.log") as f:
         contents = f.read()
@@ -743,7 +743,7 @@ def test_loadcell_initialize(loadcell_patched: Loadcell, mocker, patch_sleep):
         genvar_4=5,
         genvar_5=6,
     )
-    lc_initialize.initialize(number_of_iterations=1)
+    lc_initialize.calibrate(number_of_iterations=1)
     # Assert the data was properly updated
     assert lc_initialize._zeroed == True
     assert lc_initialize._joint._data.batt_volt == 15
@@ -921,7 +921,7 @@ def test_loadcell_initialize(loadcell_patched: Loadcell, mocker, patch_sleep):
         genvar_4=5,
         genvar_5=6,
     )
-    lc_initialize_else.initialize(number_of_iterations=1)
+    lc_initialize_else.calibrate(number_of_iterations=1)
     # Assert the proper values are returned with a couple significant figures
     assert round(lc_initialize_else.fx, -2) == round(
         loadcell_signed_dot_added_and_transposed[0][0], -2

--- a/tests/test_sensors/test_sensors.py
+++ b/tests/test_sensors/test_sensors.py
@@ -190,6 +190,11 @@ def loadcell_patched(patch_loadcell) -> Loadcell:
     return obj
 
 
+@pytest.fixture
+def patch_input(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+
 def test_mockstrainamp_init():
     """
     Test the MockStrainAmp constructor\n
@@ -698,7 +703,9 @@ def test_loadcell_update(loadcell_patched: Loadcell):
     )
 
 
-def test_loadcell_initialize(loadcell_patched: Loadcell, mocker, patch_sleep):
+def test_loadcell_initialize(
+    loadcell_patched: Loadcell, mocker, patch_sleep, patch_input
+):
     """
     Tests the Loadcell initialize method\n
     This test initializes a Loadcell object and passes data into attributes needed for testing


### PR DESCRIPTION
## Description

* `osl.calibrate_loadcell()` method now resets and calibrates the load cell. This behavior can be altered with the `reset` argument. 
* Also modified the `loadcell.calibrate()` method to accept `reset` argument from the user instead of prompting for an input to recalibrate. 

## Related Issue

#221 : Calibrate loadcell method does not work

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/imsenthur/opensourceleg/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/imsenthur/opensourceleg/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
