### PR TITLE
Fixed #217: encoder map method is missing details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ mypy:
 .PHONY: check-safety
 check-safety:
 	poetry check
-	poetry run safety check --full-report --ignore 67599
+	poetry run safety check --full-report --ignore 70612
 	poetry run bandit --recursive -c pyproject.toml opensourceleg tests
 
 .PHONY: lint

--- a/opensourceleg/hardware/joints.py
+++ b/opensourceleg/hardware/joints.py
@@ -170,7 +170,7 @@ class Joint(DephyActpack):
 
         if not self.is_homed:
             self._log.warning(
-                msg=f"[{self.__repr__()}] Please home the joint before making the encoder map."
+                msg=f"[{self.__repr__()}] Please home the {self.name} joint before making the encoder map."
             )
             return
 
@@ -193,7 +193,7 @@ class Joint(DephyActpack):
         _output_position_array = []
 
         self._log.info(
-            msg=f"[{self.__repr__()}] Please manually move the joint numerous times through its full range of motion for 10 seconds. \n{input('Press any key when you are ready to start.')}"
+            msg=f"[{self.__repr__()}] Please manually move the {self.name} joint numerous times through its full range of motion for 10 seconds. \n{input('Press any key when you are ready to start.')}"
         )
 
         _start_time: float = time.time()
@@ -201,7 +201,7 @@ class Joint(DephyActpack):
         try:
             while time.time() - _start_time < 10:
                 self._log.info(
-                    msg=f"[{self.__repr__()}] Mapping joint encoder: {10 - time.time() + _start_time} seconds left."
+                    msg=f"[{self.__repr__()}] Mapping the {self.name} joint encoder: {10 - time.time() + _start_time} seconds left."
                 )
                 self.update()
                 _joint_encoder_array.append(self._data.ank_ang)
@@ -212,7 +212,9 @@ class Joint(DephyActpack):
             self._log.warning(msg="Encoder map interrupted.")
             return
 
-        self._log.info(msg=f"[{self.__repr__()}] You may now stop moving the joint.")
+        self._log.info(
+            msg=f"[{self.__repr__()}] You may now stop moving the {self.name} joint."
+        )
 
         _power = np.arange(4.0)
         _a_mat = np.array(_joint_encoder_array).reshape(-1, 1) ** _power


### PR DESCRIPTION
## Description

* Added joint name to the log statements.

## Related Issue

#217 : Encoder map method is missing details

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/imsenthur/opensourceleg/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/imsenthur/opensourceleg/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
