### PR TITLE
Minor bug fix with colons in the logger.

### DIFF
--- a/opensourceleg/tools/logger.py
+++ b/opensourceleg/tools/logger.py
@@ -145,7 +145,7 @@ class Logger(logging.Logger):
                 else:
                     self._container_names.append(f"")
         else:
-            self._container_names.append(container_name)
+            self._container_names.append(container_name + ":")
 
         self._containers.append(container)
         self._attributes.append(attributes)

--- a/tests/test_logger/test_logger.py
+++ b/tests/test_logger/test_logger.py
@@ -124,12 +124,40 @@ def test_data():
         rows = list(reader)
         assert rows == expected_rows
 
+    # Asserts the data method works properly when passed a custom name
+    test_Logger_data = Logger(file_path="tests/test_logger/test_log_data")
     test_Logger_data.add_attributes(
-        container=test_container2, attributes=["a", "b", "c"]
+        container=test_container2,
+        attributes=["a", "b", "c"],
+        container_name="custom_name",
     )
-    # Asserts the data method works properly when passed multiple class instances
     test_Logger_data.update()
-    expected_rows2 = [["a", "b", "c"], ["1", "2", "3"], ["1", "2", "3", "1", "2", "3"]]
+    expected_rows2 = [
+        ["custom_name:a", "custom_name:b", "custom_name:c"],
+        ["1", "2", "3"],
+    ]
+    with open("tests/test_logger/test_log_data.csv", newline="") as f:
+        reader = csv.reader(f)
+        rows2 = list(reader)
+    assert rows2 == expected_rows2
+
+    # Asserts the data method works properly when passed multiple instances, including locals
+    test_Logger_data = Logger(file_path="tests/test_logger/test_log_data")
+    test_Logger_data.add_attributes(
+        container=test_container, attributes=["a", "b", "c"]
+    )
+    test_Logger_data.add_attributes(
+        container=test_container2,
+        attributes=["a", "b", "c"],
+        container_name="custom_name",
+    )
+    pi = 3.14159
+    test_Logger_data.add_attributes(locals(), ["pi"], "local")
+    test_Logger_data.update()
+    expected_rows2 = [
+        ["a", "b", "c", "custom_name:a", "custom_name:b", "custom_name:c", "local:pi"],
+        ["1", "2", "3", "1", "2", "3", "3.14159"],
+    ]
     with open("tests/test_logger/test_log_data.csv", newline="") as f:
         reader = csv.reader(f)
         rows2 = list(reader)


### PR DESCRIPTION
## Description
The logger had an issue where the colons were missing with custom container names. Fixed now. 
Also improved the tests so that this kind of thing would get caught in the future. 

## Related Issue

None, too small to make a full issue. 
## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/imsenthur/opensourceleg/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/imsenthur/opensourceleg/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
