### PR TITLE
fixes 306 too many type casting statements within the loadcell module

### DIFF
--- a/examples/fsm_walking_compiled_controller.py
+++ b/examples/fsm_walking_compiled_controller.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from opensourceleg.actuators.dephy import DephyActuator
 from opensourceleg.control.compiled import CompiledController
-from opensourceleg.sensors.loadcell import SRILoadcell
+from opensourceleg.sensors.loadcell import DephyLoadcellAmplifier
 from opensourceleg.time import SoftRealtimeLoop
 from opensourceleg.units import units
 
@@ -51,7 +51,7 @@ LOADCELL_MATRIX = np.array([
     (-0.65100, -28.28700, 0.02200, -25.23000, 0.47300, -27.3070),
 ])
 
-loadcell = SRILoadcell(
+loadcell = DephyLoadcellAmplifier(
     calibration_matrix=LOADCELL_MATRIX,
     bus=1,
 )

--- a/opensourceleg/robots/osl.py
+++ b/opensourceleg/robots/osl.py
@@ -8,7 +8,7 @@ from opensourceleg.actuators.dephy import DEFAULT_POSITION_GAINS, DephyLegacyAct
 from opensourceleg.logging import LOGGER
 from opensourceleg.robots.base import RobotBase, TActuator, TSensor
 from opensourceleg.sensors.base import LoadcellBase, SensorBase
-from opensourceleg.sensors.loadcell import SRILoadcell
+from opensourceleg.sensors.loadcell import DephyLoadcellAmplifier
 
 
 class OpenSourceLeg(RobotBase[TActuator, TSensor]):
@@ -146,7 +146,7 @@ if __name__ == "__main__":
             "knee": DephyLegacyActuator("knee", offline=False, frequency=frequency, gear_ratio=9 * (83 / 18)),
         },
         sensors={
-            "loadcell": SRILoadcell(calibration_matrix=LOADCELL_MATRIX),
+            "loadcell": DephyLoadcellAmplifier(calibration_matrix=LOADCELL_MATRIX),
         },
     )
 

--- a/opensourceleg/sensors/loadcell.py
+++ b/opensourceleg/sensors/loadcell.py
@@ -415,6 +415,6 @@ class DephyLoadcellAmplifier(LoadcellBase):
             list[float]: A 1D vector containing [Fx, Fy, Fz, Mx, My, Mz], where forces are in Newtons and moments in Nm.
         """
         if self._data is not None:
-            return self._data[0].tolist()
+            return list(map(float, self._data[0].tolist()))
         else:
-            return self._zero_calibration_offset.tolist()
+            return list(map(float, self._zero_calibration_offset.tolist()))

--- a/opensourceleg/sensors/loadcell.py
+++ b/opensourceleg/sensors/loadcell.py
@@ -1,14 +1,14 @@
 """
-Module for interfacing with SRILoadcell sensors.
+Module for interfacing with SRI Loadcell sensors.
 
-This module provides an implementation of a load cell sensor (SRILoadcell) that
+This module provides an implementation of a load cell sensor (DephyLoadcellAmplifier) that
 inherits from LoadcellBase. It uses an I2C interface via SMBus to communicate with
 a strain amplifier and processes raw ADC data to compute forces and moments.
 
 Classes:
     LoadcellNotRespondingException: Exception raised when the load cell does not respond.
     MEMORY_CHANNELS: Enum representing memory channel addresses for load cell readings.
-    SRILoadcell: Concrete implementation of a load cell sensor that provides force and moment data.
+    DephyLoadcellAmplifier: Concrete implementation of a load cell sensor that provides force and moment data.
 
 Dependencies:
     - numpy
@@ -47,7 +47,7 @@ class LoadcellNotRespondingException(Exception):
         super().__init__(message)
 
 
-class MEMORY_CHANNELS(int, Enum):
+class DEPHY_AMPLIFIER_MEMORY_CHANNELS(int, Enum):
     """
     Enumeration of memory channel addresses used by the load cell.
 
@@ -68,11 +68,11 @@ class MEMORY_CHANNELS(int, Enum):
     CH6_L = 19
 
 
-class SRILoadcell(LoadcellBase):
+class DephyLoadcellAmplifier(LoadcellBase):
     """
-    Implementation of a load cell sensor using the SRILoadcell hardware.
+    Implementation of a load cell sensor using the Dephy Loadcell Amplifier.
 
-    This class communicates with a strain amplifier via I2C using the SMBus interface,
+    This class communicates with the dephy strain amplifier via I2C using the SMBus interface,
     processes the raw ADC data, and computes forces (Fx, Fy, Fz) and moments (Mx, My, Mz)
     based on a provided calibration matrix and hardware configuration.
 
@@ -93,7 +93,7 @@ class SRILoadcell(LoadcellBase):
         i2c_address: int = 0x66,
     ) -> None:
         """
-        Initialize the SRILoadcell sensor.
+        Initialize the Dephy loadcell amplifier.
 
         Validates the provided parameters and initializes internal variables for data
         acquisition, calibration, and streaming.
@@ -258,7 +258,7 @@ class SRILoadcell(LoadcellBase):
             Any: The unpacked strain data.
         """
         try:
-            data = self._smbus.read_i2c_block_data(self._i2c_address, MEMORY_CHANNELS.CH1_H, 10)
+            data = self._smbus.read_i2c_block_data(self._i2c_address, DEPHY_AMPLIFIER_MEMORY_CHANNELS.CH1_H, 10)
             self.failed_reads = 0
         except OSError:
             self.failed_reads += 1

--- a/opensourceleg/sensors/loadcell.py
+++ b/opensourceleg/sensors/loadcell.py
@@ -407,14 +407,14 @@ class DephyLoadcellAmplifier(LoadcellBase):
         return self.data[5]
 
     @property
-    def data(self) -> float:
+    def data(self) -> list[float]:
         """
         Get the latest processed load cell data.
 
         Returns:
-            Any: A 1D vector containing [Fx, Fy, Fz, Mx, My, Mz], where forces are in Newtons and moments in Nm.
+            list[float]: A 1D vector containing [Fx, Fy, Fz, Mx, My, Mz], where forces are in Newtons and moments in Nm.
         """
         if self._data is not None:
-            return self._data[0]
+            return self._data[0].tolist()
         else:
-            return self._zero_calibration_offset
+            return self._zero_calibration_offset.tolist()

--- a/opensourceleg/sensors/loadcell.py
+++ b/opensourceleg/sensors/loadcell.py
@@ -343,7 +343,7 @@ class DephyLoadcellAmplifier(LoadcellBase):
         Returns:
             float: Force (N) along the x-axis.
         """
-        return float(self.data[0])
+        return self.data[0]
 
     @property
     def fy(self) -> float:
@@ -355,7 +355,7 @@ class DephyLoadcellAmplifier(LoadcellBase):
         Returns:
             float: Force (N) along the y-axis.
         """
-        return float(self.data[1])
+        return self.data[1]
 
     @property
     def fz(self) -> float:
@@ -368,7 +368,7 @@ class DephyLoadcellAmplifier(LoadcellBase):
         Returns:
             float: Force (N) along the z-axis.
         """
-        return float(self.data[2])
+        return self.data[2]
 
     @property
     def mx(self) -> float:
@@ -380,7 +380,7 @@ class DephyLoadcellAmplifier(LoadcellBase):
         Returns:
             float: Moment (Nm) about the x-axis.
         """
-        return float(self.data[3])
+        return self.data[3]
 
     @property
     def my(self) -> float:
@@ -392,7 +392,7 @@ class DephyLoadcellAmplifier(LoadcellBase):
         Returns:
             float: Moment (Nm) about the y-axis.
         """
-        return float(self.data[4])
+        return self.data[4]
 
     @property
     def mz(self) -> float:
@@ -404,10 +404,10 @@ class DephyLoadcellAmplifier(LoadcellBase):
         Returns:
             float: Moment (Nm) about the z-axis.
         """
-        return float(self.data[5])
+        return self.data[5]
 
     @property
-    def data(self) -> Any:
+    def data(self) -> float:
         """
         Get the latest processed load cell data.
 

--- a/tests/test_sensors/test_loadcell.py
+++ b/tests/test_sensors/test_loadcell.py
@@ -15,13 +15,13 @@ DEFAULT_CAL_MATRIX = np.ones(shape=(6, 6), dtype=np.double)
 def test_SRILoadcell_init():
     invalid_cal_matrix = np.ones(shape=(5, 6), dtype=np.double)
     with pytest.raises(TypeError):
-        SRI = loadcell.SRILoadcell(calibration_matrix=invalid_cal_matrix)
+        SRI = loadcell.DephyLoadcellAmplifier(calibration_matrix=invalid_cal_matrix)
     with pytest.raises(ValueError):
-        SRI = loadcell.SRILoadcell(calibration_matrix=DEFAULT_CAL_MATRIX, amp_gain=0)
+        SRI = loadcell.DephyLoadcellAmplifier(calibration_matrix=DEFAULT_CAL_MATRIX, amp_gain=0)
     with pytest.raises(ValueError):
-        SRI = loadcell.SRILoadcell(calibration_matrix=DEFAULT_CAL_MATRIX, exc=0)
+        SRI = loadcell.DephyLoadcellAmplifier(calibration_matrix=DEFAULT_CAL_MATRIX, exc=0)
 
-    SRI = loadcell.SRILoadcell(calibration_matrix=DEFAULT_CAL_MATRIX)
+    SRI = loadcell.DephyLoadcellAmplifier(calibration_matrix=DEFAULT_CAL_MATRIX)
 
     assert SRI._amp_gain == 125.0
     assert SRI._exc == 5.0
@@ -51,7 +51,7 @@ def test_SRILoadcell_init():
 
 
 def test_SRILoadcell_reset():
-    SRI = loadcell.SRILoadcell(calibration_matrix=DEFAULT_CAL_MATRIX)
+    SRI = loadcell.DephyLoadcellAmplifier(calibration_matrix=DEFAULT_CAL_MATRIX)
     SRI._calibration_offset = np.ones(shape=(1, 6), dtype=np.double)
     SRI.reset()
     assert np.array_equal(SRI._calibration_offset, np.zeros(shape=(1, 6), dtype=np.double))
@@ -59,7 +59,7 @@ def test_SRILoadcell_reset():
 
 def test_SRILoadcell_update():
     # Test basic call execution
-    SRI = loadcell.SRILoadcell(calibration_matrix=DEFAULT_CAL_MATRIX)
+    SRI = loadcell.DephyLoadcellAmplifier(calibration_matrix=DEFAULT_CAL_MATRIX)
     SRI.update(data_callback=_read_data)
 
     # Ensuring self._calibration_offset was used
@@ -92,7 +92,7 @@ def _read_random_data() -> npt.NDArray[np.uint8]:
 
 
 # Function to run update calculations from inside the update method
-def _update_calculations(SRI: loadcell.SRILoadcell, calibration_offset: float):
+def _update_calculations(SRI: loadcell.DephyLoadcellAmplifier, calibration_offset: float):
     test_data = _read_data()
     signed_data = ((test_data - SRI.OFFSET) / SRI.ADC_RANGE) * SRI._exc
     coupled_data = signed_data * 1000 / (SRI._exc * SRI._amp_gain)


### PR DESCRIPTION
Removed excessive typecasting in `loadcell.py`. Also renamed the class to be more explicit that it is specific to the dephy loadcell amp. 