### PR TITLE
378 dephy loadcell interface no longer supported

### DIFF
--- a/docs/tutorials/sensors/reading_loadcell_data.md
+++ b/docs/tutorials/sensors/reading_loadcell_data.md
@@ -1,56 +1,68 @@
 # Using the Dephy Loadcell Amplifier
 
-This tutorial demonstrates how to use the Dephy Loadcell Amplifier with the Open Source Leg platform to measure forces and moments.
+This tutorial demonstrates how to use the Dephy Loadcell Amplifier with the Open Source Leg platform to measure forces and moments. It includes examples for both standard I2C communication and custom callbacks for advanced use cases, including using the Dephy Actpack to interface with the amplifier directly instead of the Raspberry Pi's I2C bus.
 
 ## Hardware Setup
 
-1. Connect the loadcell to the Dephy Loadcell Amplifier and the amplifier to the Raspberry Pi via I2C
-2. Verify proper power supply connections
-3. Ensure proper grounding
-4. Mount the loadcell securely
+1. Connect the loadcell to the Dephy Loadcell Amplifier and the amplifier to the Raspberry Pi via I2C. Alternatively, raw amplifier readings can be read from the `genvars` property of the `DephyActuator` class and fed into the amplifier update method as a custom callback (see example below).
+2. Verify proper power supply connections.
+3. Ensure proper grounding.
+4. Mount the loadcell securely.
 
 This example shows how to:
 
-- Initialize and configure a Dephy Loadcell Amplifier
-- Read forces and moments (6-axis measurements)
-- Log loadcell measurements
+- Initialize and configure a Dephy Loadcell Amplifier.
+- Read forces and moments (6-axis measurements).
+- Log loadcell measurements.
+- Use custom callbacks for advanced data handling.
+
+---
 
 ## Code Structure
 
-The [tutorial script](https://github.com/neurobionics/opensourceleg/blob/main/tutorials/sensors/reading_loadcell_data.py) is organized into several main sections:
+The [tutorial script](https://github.com/neurobionics/opensourceleg/blob/main/tutorials/sensors/reading_loadcell_data.py) for reading loadcell data has two main functions. The first shows the standard implementation where the I2C bus on a Raspberry Pi is used to communicate with the strain amplifier. The second shows an alternative use where raw ADC values are passed to the sensor in a custom data callback function. This second implementation is useful when the raw values are provided via a method other than I2C, such as reading them directly from a Dephy Actuator.
 
 ### 1. Initialization
 
 ```python
---8<-- "tutorials/sensors/reading_loadcell_data.py:1:40"
+--8<-- "tutorials/sensors/reading_loadcell_data.py:1:25"
 ```
 
 This section:
 
 - Sets up constants and configuration parameters
 - Defines the calibration matrix
-- Creates a data logger for recording measurements
-- Sets up a real-time loop for consistent timing
-- Initializes the DephyLoadcellAmplifier with specified parameters
 
-### 2. Main Loop
+### 2. Standard Setup with I2C Communication
+
+This section demonstrates how to use the loadcell with standard I2C communication. It includes:
+
+- Initializing the loadcell with I2C parameters.
+- Calibrating the loadcell.
+- Reading and logging force/torque data.
 
 ```python
---8<-- "tutorials/sensors/reading_loadcell_data.py:48:55"
+--8<-- "tutorials/sensors/reading_loadcell_data.py:28:53"
 ```
 
-The main loop:
+### 3. Custom Callback Communication
+This section demonstrates how to use a custom callback to provide raw data to the loadcell. It includes:
 
-1. Updates the loadcell to get the latest reading
-2. Logs the time and current force/torque values
-3. Updates the logger
-
-## Loadcell Parameters
-
-When initializing the DephyLoadcellAmplifier, several important parameters can be configured:
+- Using a DephyActuator to retrieve raw amplifier readings.
+- Passing the raw data to the loadcell using a callback function.
+- Calibrating the loadcell with the custom callback.
+- Reading and logging force/torque data.
 
 ```python
---8<-- "tutorials/sensors/reading_loadcell_data.py:32:40"
+--8<-- "tutorials/sensors/reading_loadcell_data.py:56:90"
+```
+
+## Important Class Parameters
+
+When initializing the `DephyLoadcellAmplifier`, several important parameters can be configured:
+
+```python
+--8<-- "tutorials/sensors/reading_loadcell_data.py:29:36"
 ```
 
 ### Parameter Details
@@ -86,7 +98,7 @@ When initializing the DephyLoadcellAmplifier, several important parameters can b
 
 ## Available Properties
 
-The DephyLoadcellAmplifier provides six measurement properties:
+The `DephyLoadcellAmplifier` provides six measurement properties:
 
 1. **Forces** (fx, fy, fz):
       - Linear forces in Newtons (N)
@@ -115,13 +127,19 @@ The DephyLoadcellAmplifier provides six measurement properties:
 
 2. Run the script:
    ```bash
-   python loadcell.py
+   python reading_loadcell_data.py
    ```
 
 3. Expected behavior:
       - Loadcell begins reading force/torque data continuously at 200Hz
       - Data is logged to `./logs/reading_loadcell_data.csv`
       - Force and moment values update as you apply loads to the sensor
+
+4. To change between I2C and using custom data callbacks, swap the `if __name__ == "__main__"` between the two demo function calls:
+
+```python
+--8<-- "tutorials/sensors/reading_loadcell_data.py:101:102"
+```
 
 ## Common Issues
 
@@ -141,18 +159,6 @@ LOADCELL_CALIBRATION_MATRIX = np.array([
     # ... additional rows ...
 ])
 ```
-Should be replaced with your specific loadcell's calibration values.
-
-## Best Practices
-
-1. **Before Each Use**
-
-      - Verify all connections
-
-2. **Maintenance**
-
-      - Regular calibration checks
-      - Clean connections
-      - Monitor for drift
+should be replaced with your specific loadcell's calibration values.
 
 If you have any questions or need further assistance, please post on the [Open Source Leg community forum](https://opensourceleg.org/community).

--- a/opensourceleg/sensors/loadcell.py
+++ b/opensourceleg/sensors/loadcell.py
@@ -2,13 +2,12 @@
 Module for interfacing with Loadcell amplifiers.
 
 This module provides an implementation of a load cell amplifier (DephyLoadcellAmplifier) that
-inherits from LoadcellBase. It uses either an I2C interface via SMBus or direct communication with an ActPack
+inherits from LoadcellBase. It uses either an I2C interface via SMBus or a custom data callback function 
 to communicate with a strain amplifier and processes raw ADC data to compute forces and moments.
 
 Classes:
     LoadcellNotRespondingException: Exception raised when the load cell does not respond.
     DEPHY_AMPLIFIER_MEMORY_CHANNELS: Enum representing memory channel addresses for load cell readings.
-    DEPHY_AMPLIFIER_CONNECTION_MODES: Enum representing connection modes for the load cell amplifier.
     DephyLoadcellAmplifier: Concrete implementation of a load cell sensor that provides force and moment data.
 
 Dependencies:
@@ -16,7 +15,6 @@ Dependencies:
     - smbus2
     - opensourceleg.logging
     - opensourceleg.sensors.base
-    - opensourceleg.actuators.dephy
 """
 
 import time
@@ -75,7 +73,7 @@ class DephyLoadcellAmplifier(LoadcellBase):
     Implementation of a load cell sensor using the Dephy Loadcell Amplifier.
 
     This class communicates with the Dephy strain amplifier.
-    It can connect via either I2C using the SMBus interface, or directly via an ActPack.
+    It can connect via either I2C using the SMBus interface, or using custom data callbacks. 
     It processes the raw ADC data, and computes forces (Fx, Fy, Fz) and moments (Mx, My, Mz)
     based on a provided calibration matrix and hardware configuration.
 
@@ -151,7 +149,6 @@ class DephyLoadcellAmplifier(LoadcellBase):
 
         If using I2C Mode, it opens the I2C connection using SMBus, waits briefly for hardware stabilization,
         and sets the streaming flag to True.
-        If using ACTPACK mode, ensures the ActPack instance is provided and streaming.
         """
         self._smbus = SMBus(self._bus)
         time.sleep(1)
@@ -174,7 +171,7 @@ class DephyLoadcellAmplifier(LoadcellBase):
         """
         Query the load cell for the latest data and update internal state.
 
-        Reads raw ADC data (either via a provided callback or by reading from I2C/ActPack),
+        Reads raw ADC data (either via a provided callback or by reading from I2C),
         converts it to engineering units using the calibration matrix, amplifier gain,
         and excitation voltage, and subtracts any calibration offset.
 
@@ -182,7 +179,7 @@ class DephyLoadcellAmplifier(LoadcellBase):
             calibration_offset (Optional[npt.NDArray[np.double]], optional):
                 An offset to subtract from the processed data. If None, uses the current calibration offset.
             data_callback (Optional[Callable[..., npt.NDArray[np.uint8]]], optional):
-                A callback function to provide raw data. If not provided, the sensor's internal method is used.
+                A callback function to provide raw data. If not provided, the sensor's internal i2c method is used.
 
         Raises:
             ValueError: If the update method fails due to misconfiguration.

--- a/opensourceleg/sensors/loadcell.py
+++ b/opensourceleg/sensors/loadcell.py
@@ -2,7 +2,7 @@
 Module for interfacing with Loadcell amplifiers.
 
 This module provides an implementation of a load cell amplifier (DephyLoadcellAmplifier) that
-inherits from LoadcellBase. It uses either an I2C interface via SMBus or a custom data callback function 
+inherits from LoadcellBase. It uses either an I2C interface via SMBus or a custom data callback function
 to communicate with a strain amplifier and processes raw ADC data to compute forces and moments.
 
 Classes:
@@ -73,7 +73,7 @@ class DephyLoadcellAmplifier(LoadcellBase):
     Implementation of a load cell sensor using the Dephy Loadcell Amplifier.
 
     This class communicates with the Dephy strain amplifier.
-    It can connect via either I2C using the SMBus interface, or using custom data callbacks. 
+    It can connect via either I2C using the SMBus interface, or using custom data callbacks.
     It processes the raw ADC data, and computes forces (Fx, Fy, Fz) and moments (Mx, My, Mz)
     based on a provided calibration matrix and hardware configuration.
 

--- a/tutorials/sensors/reading_loadcell_data.py
+++ b/tutorials/sensors/reading_loadcell_data.py
@@ -24,6 +24,7 @@ LOADCELL_CALIBRATION_MATRIX = np.array([
     (-0.65100, -28.28700, 0.02200, -25.23000, 0.47300, -27.3070),
 ])
 
+
 def demo_loadcell_i2c(loadcell_logger, clock):
     loadcell = DephyLoadcellAmplifier(
         calibration_matrix=LOADCELL_CALIBRATION_MATRIX,
@@ -40,7 +41,7 @@ def demo_loadcell_i2c(loadcell_logger, clock):
     loadcell_logger.track_variable(lambda: loadcell.mx, "Mx")
     loadcell_logger.track_variable(lambda: loadcell.my, "My")
     loadcell_logger.track_variable(lambda: loadcell.mz, "Mz")
-    
+
 
 def demo_loadcell_actpack(loadcell_logger, clock):
     actpack = DephyActuator(
@@ -67,7 +68,7 @@ def demo_loadcell_actpack(loadcell_logger, clock):
     def get_raw_loadcell_actpack():
         actpack.update()
         return actpack.genvars
-    
+
     with actpack, loadcell:
         loadcell.calibrate(reset=True, data_callback=get_raw_loadcell_actpack)
         for t in clock:
@@ -78,7 +79,7 @@ def demo_loadcell_actpack(loadcell_logger, clock):
             )
             loadcell_logger.update()
 
-    
+
 if __name__ == "__main__":
     loadcell_logger = Logger(
         log_path="./logs",
@@ -87,5 +88,5 @@ if __name__ == "__main__":
 
     clock = SoftRealtimeLoop(dt=DT)
 
-    demo_loadcell_actpack(loadcell_logger=loadcell_logger, clock = clock)
+    demo_loadcell_actpack(loadcell_logger=loadcell_logger, clock=clock)
     # demo_loadcell_i2c(loadcell_logger=loadcell_logger, clock = clock)

--- a/tutorials/sensors/reading_loadcell_data.py
+++ b/tutorials/sensors/reading_loadcell_data.py
@@ -42,6 +42,16 @@ def demo_loadcell_i2c(loadcell_logger, clock):
     loadcell_logger.track_variable(lambda: loadcell.my, "My")
     loadcell_logger.track_variable(lambda: loadcell.mz, "Mz")
 
+    with loadcell:
+        loadcell.calibrate(reset=True)
+        for t in clock:
+            loadcell.update()
+            loadcell_logger.info(
+                f"Time: {t}; Fx: {loadcell.fx}; Fy: {loadcell.fy}; Fz: {loadcell.fz};"
+                f"Mx: {loadcell.mx}; My: {loadcell.my}; Mz: {loadcell.mz};"
+            )
+            loadcell_logger.update()
+
 
 def demo_loadcell_actpack(loadcell_logger, clock):
     actpack = DephyActuator(

--- a/tutorials/sensors/reading_loadcell_data.py
+++ b/tutorials/sensors/reading_loadcell_data.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from opensourceleg.actuators.dephy import DephyActuator
 from opensourceleg.logging.logger import Logger
 from opensourceleg.sensors.loadcell import DephyLoadcellAmplifier
 from opensourceleg.utilities import SoftRealtimeLoop
@@ -23,12 +24,7 @@ LOADCELL_CALIBRATION_MATRIX = np.array([
     (-0.65100, -28.28700, 0.02200, -25.23000, 0.47300, -27.3070),
 ])
 
-if __name__ == "__main__":
-    loadcell_logger = Logger(
-        log_path="./logs",
-        file_name="reading_loadcell_data",
-    )
-    clock = SoftRealtimeLoop(dt=DT)
+def demo_loadcell_i2c(loadcell_logger, clock):
     loadcell = DephyLoadcellAmplifier(
         calibration_matrix=LOADCELL_CALIBRATION_MATRIX,
         tag="loadcell",
@@ -44,12 +40,52 @@ if __name__ == "__main__":
     loadcell_logger.track_variable(lambda: loadcell.mx, "Mx")
     loadcell_logger.track_variable(lambda: loadcell.my, "My")
     loadcell_logger.track_variable(lambda: loadcell.mz, "Mz")
+    
 
-    with loadcell:
+def demo_loadcell_actpack(loadcell_logger, clock):
+    actpack = DephyActuator(
+        port="/dev/ttyACM1",
+        gear_ratio=9,
+        frequency=FREQUENCY,
+        debug_level=0,
+        dephy_log=False,
+    )
+
+    loadcell = DephyLoadcellAmplifier(
+        calibration_matrix=LOADCELL_CALIBRATION_MATRIX,
+        tag="loadcell",
+        amp_gain=125,
+        exc=5,
+    )
+    loadcell_logger.track_variable(lambda: loadcell.fx, "Fx")
+    loadcell_logger.track_variable(lambda: loadcell.fy, "Fy")
+    loadcell_logger.track_variable(lambda: loadcell.fz, "Fz")
+    loadcell_logger.track_variable(lambda: loadcell.mx, "Mx")
+    loadcell_logger.track_variable(lambda: loadcell.my, "My")
+    loadcell_logger.track_variable(lambda: loadcell.mz, "Mz")
+
+    def get_raw_loadcell_actpack():
+        actpack.update()
+        return actpack.genvars
+    
+    with actpack, loadcell:
+        loadcell.calibrate(reset=True, data_callback=get_raw_loadcell_actpack)
         for t in clock:
-            loadcell.update()
+            loadcell.update(data_callback=get_raw_loadcell_actpack)
             loadcell_logger.info(
                 f"Time: {t}; Fx: {loadcell.fx}; Fy: {loadcell.fy}; Fz: {loadcell.fz};"
                 f"Mx: {loadcell.mx}; My: {loadcell.my}; Mz: {loadcell.mz};"
             )
             loadcell_logger.update()
+
+    
+if __name__ == "__main__":
+    loadcell_logger = Logger(
+        log_path="./logs",
+        file_name="reading_loadcell_data",
+    )
+
+    clock = SoftRealtimeLoop(dt=DT)
+
+    demo_loadcell_actpack(loadcell_logger=loadcell_logger, clock = clock)
+    # demo_loadcell_i2c(loadcell_logger=loadcell_logger, clock = clock)


### PR DESCRIPTION
Fixes 378. No change to actual library functionality. Rather just wrote an example on how to make it work with the dephy actpack and custom data callbacks. 