### PR TITLE
enh: [Moteus Interface] Pi3Hat Update and Stop Feature to be Improved #258

### DIFF
--- a/opensourceleg/actuators/moteus.py
+++ b/opensourceleg/actuators/moteus.py
@@ -135,7 +135,7 @@ class MoteusInterface:
 
         return cls._instance
 
-    def __init__(self, batch=False):
+    def __init__(self):
         pass
 
     def __repr__(self):


### PR DESCRIPTION
This PR adds batching functionality to moteus actuator commands. Currently, each command is individually processed in the `MoteusActuator` class which underutilizes the capability of the `pi3hat` to concurrently process commands.

The PR implements the `MoteusInterface.update()` and `stop()` methods which will be called by a user defined loop. To distinguish between batching and the current implementation, users can specify `batch=True` as an argument when initializing `MoteusInterface`. When batching is enabled, on update, all commands specified for particular actuators will be sent, while defaulting to a query if no command is specified for a cycle.  

While the queueing is done under the hood for `update`, the user will need to call `enqueue_stop_command` in the `MoteusActuator` class to properly batch with `MoteusActuator.stop`.

This logic also warns the user of potential misuse between the update and stop methods from the `MoteusInterface` and `MoteusActuator` classes.

Example usage:
```
interface = MoteusInterface(batch=True)

# Control loop
actuator1.set_motor_torque(x)
actuator2.set_motor_position(y)
await interface.update()
# End of control loop

actuator1.enqueue_stop_command()
actuator2.enqueue_stop_command()
await interface.stop()
```