### PR TITLE
Update tmotor_CAN_Servo.py

### DIFF
--- a/opensourceleg/actuators/Tmotor_Servo_CAN.py
+++ b/opensourceleg/actuators/Tmotor_Servo_CAN.py
@@ -935,7 +935,7 @@ class TMotorManager_servo_can():
             vel: The desired output speed in rad/s
         """
         if np.abs(vel) >= Servo_Params[self.type]["V_max"]:
-            raise RuntimeError("Cannot control using speed mode for angles with magnitude greater than " + str(Servo_Params[self.type]["V_max"]) + "rad/s!")
+            raise RuntimeError("Cannot control using speed mode for velocities with magnitude greater than " + str(Servo_Params[self.type]["V_max"]) + "rad/s!")
 
         if self._control_state not in [_TMotorManState_Servo.VELOCITY]:
             raise RuntimeError("Attempted to send speed command without gains for device " + self.device_info_string()) 
@@ -1056,7 +1056,7 @@ class TMotorManager_servo_can():
     # Pretty stuff
     def __str__(self):
         """Prints the motor's device info and current"""
-        return self.device_info_string() + " | Position: " + '{: 1f}'.format(round(self.position,3)) + " rad | Velocity: " + '{: 1f}'.format(round(self.velocity,3)) + " rad/s | current: " + '{: 1f}'.format(round(self.current_qaxis,3)) + " A | temp: " + '{: 1f}'.format(round(self.temperature,0)) + " C"
+        return self.device_info_string() + " | Position: " + '{:.3f}'.format(self.position) + " rad | Velocity: " + '{:.3f}'.format(self.velocity) + " rad/s | current: " + '{:.3f}'.format(self.current_qaxis) + " A | temp: " + '{:.0f}'.format(self.temperature) + " C"
 
     def device_info_string(self):
         """Prints the motor's ID and device type."""
@@ -1079,18 +1079,18 @@ class TMotorManager_servo_can():
             self.power_on()
             time.sleep(0.001)
         success = True
-        # time.sleep(0.1)
-        # for i in range(10):
-        #     if Listener.get_message(timeout=0.1) is None:
-        #         success = False
-        # self._canman.notifier.remove_listener(Listener)
+        time.sleep(0.1)  # Allow time for responses
+        for i in range(10):
+            if Listener.get_message(timeout=0.1) is None:  # Check for replies
+                success = False
+        self._canman.notifier.remove_listener(Listener)  # Remove listener to prevent memory leaks
         return success
 
     # Properties
     temperature = property(get_temperature_celsius, doc="temperature_degrees_C")
     """Temperature in Degrees Celsius"""
 
-    error = property(get_motor_error_code, doc="temperature_degrees_C")
+    error = property(get_motor_error_code, doc="motor_error_code")
     """Motor error code. 0 means no error.
     
     Codes:
@@ -1144,5 +1144,8 @@ class TMotorManager_servo_can():
 
     torque_motorside = property(get_motor_torque_newton_meters, set_motor_torque_newton_meters, doc="motor_torque_newton_meters")
     """Motor-side torque in Nm"""
+
+
+
 
 

--- a/opensourceleg/actuators/__init__.py
+++ b/opensourceleg/actuators/__init__.py
@@ -1,3 +1,4 @@
 from .base import *  # noqa: F403
 from .decorators import *  # noqa: F403
 from .dephy import *  # noqa: F403
+from .tmotor import *  # noqa: F403

--- a/opensourceleg/actuators/tmotor
+++ b/opensourceleg/actuators/tmotor
@@ -151,7 +151,7 @@ class ServoMotorState:
     error: int = 0
     acceleration: float = 0.0
 
-    def set_state(self, position: float, velocity: float, current: float, 
+    def set_state(self, position: float, velocity: float, current: float,
                   temperature: float, error: int, acceleration: float) -> None:
         """Update all state values."""
         self.position = position
@@ -183,7 +183,7 @@ class ServoCommand:
 
 class CANManagerServo:
     """Singleton CAN manager for servo mode communication."""
-    
+
     _instance: Optional['CANManagerServo'] = None
     _initialized: bool = False
     debug: bool = False
@@ -199,21 +199,21 @@ class CANManagerServo:
         """Initialize CAN bus connection."""
         if self._initialized:
             return
-        
+
         LOGGER.info("Initializing CAN Manager for TMotor Servo Mode")
-        
+
         try:
             # Configure CAN interface for Linux/RPi
             os.system('sudo /sbin/ip link set can0 down')
             os.system('sudo /sbin/ip link set can0 up type can bitrate 1000000')
             os.system('sudo ifconfig can0 txqueuelen 1000')
-            
+
             self.bus = can.interface.Bus(channel='can0', bustype='socketcan')
             self.notifier = can.Notifier(bus=self.bus, listeners=[])
-            
+
             LOGGER.info(f"CAN bus connected: {self.bus}")
             self._initialized = True
-            
+
         except Exception as e:
             LOGGER.error(f"CAN bus initialization failed: {e}")
             raise RuntimeError("CAN bus initialization failed") from e
@@ -234,12 +234,12 @@ class CANManagerServo:
         """Send CAN message to motor."""
         if data_len > 8:
             raise ValueError(f'Data too long in message for motor {motor_id}')
-        
+
         if self.debug:
             LOGGER.info(f'ID: {hex(motor_id)}   Data: [{", ".join(hex(d) for d in data)}]')
-        
+
         message = can.Message(arbitration_id=motor_id, data=data, is_extended_id=True)
-        
+
         try:
             self.bus.send(message)
             if self.debug:
@@ -288,7 +288,7 @@ class CANManagerServo:
         message_id = controller_id | (SERVO_PARAMS['CAN_PACKET_ID']['CAN_PACKET_SET_POS'] << 8)
         self.send_message(message_id, buffer, len(buffer))
 
-    def set_position_velocity(self, controller_id: int, position: float, 
+    def set_position_velocity(self, controller_id: int, position: float,
                             velocity: float, acceleration: float) -> None:
         """Send position control with velocity profile."""
         buffer = []
@@ -312,44 +312,50 @@ class CANManagerServo:
 
     @staticmethod
     def _pack_int16(number: int) -> list:
-        """Pack 16-bit integer into byte list."""
-        return [(number >> 8) & 0xFF, number & 0xFF]
+        """Pack 16-bit signed integer into byte list (little-endian)."""
+        # Handle negative numbers with 2's complement
+        if number < 0:
+            number = (1 << 16) + number
+        return [number & 0xFF, (number >> 8) & 0xFF]
 
     @staticmethod
     def _pack_int32(number: int) -> list:
-        """Pack 32-bit integer into byte list."""
-        return [(number >> 24) & 0xFF, (number >> 16) & 0xFF, 
-                (number >> 8) & 0xFF, number & 0xFF]
+        """Pack 32-bit signed integer into byte list (little-endian)."""
+        # Handle negative numbers with 2's complement
+        if number < 0:
+            number = (1 << 32) + number
+        return [number & 0xFF, (number >> 8) & 0xFF,
+                (number >> 16) & 0xFF, (number >> 24) & 0xFF]
 
     def parse_servo_message(self, data: bytes) -> ServoMotorState:
         """Parse received servo message into motor state."""
         if len(data) < 8:
             raise ValueError(f"Invalid message length: {len(data)}")
-            
+
         # Parse according to TMotor servo protocol
         pos_int = int.from_bytes(data[0:2], byteorder='little', signed=True)
         spd_int = int.from_bytes(data[2:4], byteorder='little', signed=True)
         cur_int = int.from_bytes(data[4:6], byteorder='little', signed=True)
-        
+
         motor_pos = float(pos_int * 0.1)  # Position in degrees (0.1 deg resolution)
         motor_spd = float(spd_int * 10.0)  # Speed in ERPM
         motor_cur = float(cur_int / 1000.0)  # Current in amps (protocol: 1000 = 1A)
         motor_temp = float(data[6])  # Temperature in Celsius
         motor_error = int(data[7])  # Error code
-        
+
         if self.debug:
             LOGGER.info(f"Position: {motor_pos}")
             LOGGER.info(f"Velocity: {motor_spd}")
             LOGGER.info(f"Current: {motor_cur}")
             LOGGER.info(f"Temp: {motor_temp}")
             LOGGER.info(f"Error: {motor_error}")
-            
+
         return ServoMotorState(motor_pos, motor_spd, motor_cur, motor_temp, motor_error, 0.0)
 
 
 class MotorListener(can.Listener):
     """CAN message listener for motor updates."""
-    
+
     def __init__(self, canman: CANManagerServo, motor: 'TMotorServoActuator') -> None:
         """Initialize listener."""
         self.canman = canman
@@ -461,7 +467,7 @@ TMOTOR_SERVO_CONTROL_MODE_CONFIGS = CONTROL_MODE_CONFIGS(
 # Default variables to be logged
 LOG_VARIABLES = [
     "motor_position",
-    "motor_speed", 
+    "motor_speed",
     "motor_current",
     "motor_temperature"
 ]
@@ -533,7 +539,7 @@ class TMotorServoActuator(ActuatorBase):
         self.motor_type = motor_type
         self.ID = motor_ID
         self.max_temperature = max_temperature
-        
+
         # Logging configuration
         self.csv_file_name = CSV_file
         self.log_vars = log_vars or LOG_VARIABLES
@@ -601,14 +607,14 @@ class TMotorServoActuator(ActuatorBase):
     def __enter__(self) -> 'TMotorServoActuator':
         """Used to safely power the motor on and begin the log file."""
         LOGGER.info(f'Turning on control for device: {self.device_info_string()}')
-        
+
         if self.csv_file_name is not None:
             with open(self.csv_file_name, 'w') as fd:
                 writer = csv.writer(fd)
                 writer.writerow(["pi_time"] + self.log_vars)
             self.csv_file = open(self.csv_file_name, 'a').__enter__()
             self.csv_writer = csv.writer(self.csv_file)
-        
+
         self.start()
         return self
 
@@ -627,15 +633,15 @@ class TMotorServoActuator(ActuatorBase):
     def start(self) -> None:
         """Start the actuator and enable control."""
         LOGGER.info(f"Starting control for {self.device_info_string()}")
-        
+
         if not self.is_offline:
             self._canman.power_on(self.ID)
         self._send_command()
-            
+
             # Verify connection
         if not self.check_can_connection():
                 raise RuntimeError(f"Device not connected: {self.device_info_string()}")
-        
+
         self._entered = True
         self._is_open = True
         self._is_streaming = True
@@ -645,10 +651,10 @@ class TMotorServoActuator(ActuatorBase):
     def stop(self) -> None:
         """Stop the actuator and disable control."""
         LOGGER.info(f"Stopping control for {self.device_info_string()}")
-        
+
         if not self.is_offline:
             self._canman.power_off(self.ID)
-        
+
         self._is_open = False
         self._is_streaming = False
 
@@ -664,10 +670,10 @@ class TMotorServoActuator(ActuatorBase):
 
         # Communication timeout check
         now = time.time()
-        if (self._last_command_time is not None and 
-            (now - self._last_command_time) < 0.25 and 
+        if (self._last_command_time is not None and
+            (now - self._last_command_time) < 0.25 and
             (now - self._last_update_time) > 0.1):
-            warnings.warn(f"No data from motor. Check connection: {self.device_info_string()}", 
+            warnings.warn(f"No data from motor. Check connection: {self.device_info_string()}",
                          RuntimeWarning, stacklevel=2)
         else:
             self._command_sent = False
@@ -675,7 +681,7 @@ class TMotorServoActuator(ActuatorBase):
         # Update state
         self._motor_state.set_state_obj(self._motor_state_async)
         self._motor_state.position = self._motor_state.position / self._params['GEAR_RATIO']
-        
+
         # Send command
         if not self.is_offline:
             self._send_command()
@@ -713,10 +719,10 @@ class TMotorServoActuator(ActuatorBase):
                 self._canman.set_duty_cycle(self.ID, 0.0)
             else:
                 self._canman.set_duty_cycle(self.ID, 0.0)
-                
+
             self._last_command_time = time.time()
             self._command_sent = True
-            
+
         except Exception as e:
             LOGGER.error(f"Failed to send command: {e}")
             raise
@@ -735,12 +741,12 @@ class TMotorServoActuator(ActuatorBase):
         now = time.time()
         dt = now - self._last_update_time
         self._last_update_time = now
-        
+
         # Calculate acceleration
         if dt > 0:
             self._motor_state_async.acceleration = (
                 servo_state.velocity - self._motor_state_async.velocity) / dt
-        
+
         self._motor_state_async.set_state_obj(servo_state)
         self._updated = True
 
@@ -755,13 +761,13 @@ class TMotorServoActuator(ActuatorBase):
     ) -> None:
         """
         Home the actuator by setting current position as zero.
-        
+
         For servo mode, this simply sets the current position as the origin.
         """
         if not self.is_offline:
             self._canman.set_origin(self.ID, 1)  # Set permanent zero point
             time.sleep(0.1)  # Allow command to process
-        
+
         self._is_homed = True
         LOGGER.info(f"Homed actuator: {self.device_info_string()}")
 
@@ -769,30 +775,30 @@ class TMotorServoActuator(ActuatorBase):
         """Check CAN connection by sending test messages."""
         if self.is_offline:
             return True
-            
+
         if not self._entered:
             raise RuntimeError("Cannot check connection before starting motor control")
 
         listener = can.BufferedReader()
         self._canman.notifier.add_listener(listener)
-        
+
         try:
             # Send test messages
             for _ in range(10):
                 self._canman.power_on(self.ID)
                 time.sleep(0.001)
-            
+
             time.sleep(0.1)  # Wait for responses
-            
+
             # Check for replies
             success = True
             for _ in range(10):
                 if listener.get_message(timeout=0.1) is None:
                     success = False
                     break
-                    
+
             return success
-            
+
         finally:
             self._canman.notifier.remove_listener(listener)
 
@@ -830,20 +836,20 @@ class TMotorServoActuator(ActuatorBase):
 
     def get_output_torque_newton_meters(self) -> float:
         """Get output torque in Nm."""
-        return (self.get_current_qaxis_amps() * 
-                self._params["Kt_actual"] * 
+        return (self.get_current_qaxis_amps() *
+                self._params["Kt_actual"] *
                 self._params["GEAR_RATIO"])
 
     def get_motor_angle_radians(self) -> float:
         """Get motor angle in radians."""
-        return (self._motor_state.position * 
-                self.rad_per_degree * 
+        return (self._motor_state.position *
+                self.rad_per_degree *
                 self._params["GEAR_RATIO"])
 
     def get_motor_velocity_radians_per_second(self) -> float:
         """Get motor velocity in radians per second."""
-        return (self._motor_state.velocity * 
-                self.radps_per_erpm * 
+        return (self._motor_state.velocity *
+                self.radps_per_erpm *
                 self._params["GEAR_RATIO"])
 
     def get_motor_acceleration_radians_per_second_squared(self) -> float:
@@ -893,11 +899,11 @@ class TMotorServoActuator(ActuatorBase):
             raise RuntimeError(
                 f"Cannot control position with magnitude greater than {p_max_deg} degrees!"
             )
-        
+
         pos = (pos / self.rad_per_degree)  # Convert to degrees for protocol
         vel = (vel / self.radps_per_erpm)
         acc = (acc / self.radps_per_erpm)
-        
+
         if self._servo_mode == ServoControlMode.POSITION_VELOCITY:
             self._command.position = pos
             self._command.velocity = vel
@@ -913,9 +919,10 @@ class TMotorServoActuator(ActuatorBase):
         """Set duty cycle (-1 to 1)."""
         if self._servo_mode != ServoControlMode.DUTY_CYCLE:
             raise RuntimeError(
-                f"Attempted to send duty cycle command without entering duty cycle mode for device {self.device_info_string()}"
+                f"Attempted to send duty cycle command without entering duty cycle mode "
+                f"for device {self.device_info_string()}"
             )
-        
+
         if abs(duty) > 1:
             raise RuntimeError("Cannot control using duty cycle mode for duty cycles greater than 100%!")
         self._command.duty = duty
@@ -931,21 +938,25 @@ class TMotorServoActuator(ActuatorBase):
             )
 
         if self._servo_mode != ServoControlMode.VELOCITY:
-            raise RuntimeError("Attempted to send speed command without entering velocity mode for device " + self.device_info_string())
-        
+            raise RuntimeError(
+                f"Attempted to send speed command without entering velocity mode "
+                f"for device {self.device_info_string()}"
+            )
+
         self._command.velocity = vel_erpm
 
     def set_motor_current_qaxis_amps(self, current: float) -> None:
         """Set motor current in amps."""
         if self._servo_mode not in [ServoControlMode.CURRENT_LOOP, ServoControlMode.CURRENT_BRAKE]:
             raise RuntimeError(
-                f"Attempted to send current command before entering current mode for device {self.device_info_string()}"
+                f"Attempted to send current command before entering current mode "
+                f"for device {self.device_info_string()}"
             )
-        
+
         # Check current limits based on control mode and motor parameters
         curr_min = self._params['Curr_min'] / 1000.0  # Convert from protocol units to amps
         curr_max = self._params['Curr_max'] / 1000.0  # Convert from protocol units to amps
-        
+
         if self._servo_mode == ServoControlMode.CURRENT_BRAKE:
             # Current brake mode: 0 to max current only
             if current < 0 or current > curr_max:
@@ -953,8 +964,10 @@ class TMotorServoActuator(ActuatorBase):
         else:
             # Current loop mode: min to max current
             if current < curr_min or current > curr_max:
-                raise RuntimeError(f"Current loop mode requires current between {curr_min}A to {curr_max}A, got {current}A")
-        
+                raise RuntimeError(
+                    f"Current loop mode requires current between {curr_min}A to {curr_max}A, got {current}A"
+                )
+
         self._command.current = current
 
     def set_output_torque_newton_meters(self, torque: float) -> None:
@@ -997,7 +1010,9 @@ class TMotorServoActuator(ActuatorBase):
         value_deg = value * 180.0 / np.pi
         p_max_deg = self._params['P_max'] * 0.1  # Convert from protocol units to degrees
         if abs(value_deg) >= p_max_deg:
-            raise ValueError(f"Position {value_deg}° exceeds motor limits (±{p_max_deg}°)")
+            raise ValueError(
+                f"Position {value_deg}° exceeds motor limits (±{p_max_deg}°)"
+            )
         self._command.position = value_deg  # Store in degrees
 
     def set_output_position(self, value: float) -> None:
@@ -1022,7 +1037,7 @@ class TMotorServoActuator(ActuatorBase):
         """Set position control gains (stored for reference)."""
         self._position_gains = ControlGains(kp=kp, ki=ki, kd=kd, ff=ff)
 
-    def set_impedance_gains(self, kp: float, ki: float, kd: float, 
+    def set_impedance_gains(self, kp: float, ki: float, kd: float,
                           k: float, b: float, ff: float) -> None:
         """Set impedance control gains."""
         self._impedance_gains = ControlGains(kp=kp, ki=ki, kd=kd, k=k, b=b, ff=ff)
@@ -1178,50 +1193,50 @@ class TMotorServoActuator(ActuatorBase):
 if __name__ == "__main__":
     # Current Loop Control Example
     # Focus: Send torque commands and read motor parameters
-    
+
     import time
     from opensourceleg.utilities.softrealtimeloop import SoftRealtimeLoop
     try:
         with TMotorServoActuator(motor_type="AK80-9", motor_ID=1, offline=True) as motor:
             print(f"Motor: {motor.device_info_string()}")
-            
+
             # Initialize
             motor.home()
             motor.set_control_mode(CONTROL_MODES.CURRENT)
             print("Current loop mode activated")
-            
+
             # Control loop: Send torque commands and read parameters
             loop = SoftRealtimeLoop(dt=0.01, report=True, fade=0)
-            
+
             for t in loop:
                 if t > 10.0:  # Run for 10 seconds
                     break
-                
+
                 # Send torque command (example: 5Nm sine wave)
                 torque_command = 5.0 * np.sin(2 * np.pi * 0.5 * t)  # 5Nm, 0.5Hz
                 motor.set_output_torque(torque_command)
-                
+
                 # Update motor state
                 motor.update()
-                
+
                 # Read motor parameters
                 position = motor.output_position  # rad
                 velocity = motor.output_velocity  # rad/s
                 current = motor.motor_current     # A
                 temperature = motor.case_temperature  # °C
-                
+
                 # Display every 0.5 seconds
                 if int(t * 2) % 1 == 0:
                     print(f"t={t:4.1f}s | Torque={torque_command:5.1f}Nm | "
                           f"Pos={position:6.3f}rad | Vel={velocity:6.2f}rad/s | "
                           f"Curr={current:5.1f}A | Temp={temperature:4.1f}°C")
-            
+
             # Stop motor
             motor.set_output_torque(0.0)
             motor.update()
             print("Motor stopped")
-            
+
     except Exception as e:
         print(f"Error: {e}")
-    
+
     print("Example completed")

--- a/opensourceleg/actuators/tmotor
+++ b/opensourceleg/actuators/tmotor
@@ -1,125 +1,159 @@
-import can
+import os
 import time
+import warnings
 import csv
 import traceback
 from enum import Enum
+from math import isfinite
+from typing import Optional, Any, Dict, Union
+from dataclasses import dataclass
+
+import can
 import numpy as np
-import warnings
-import os
 
-# Control mode contain {0,1,2,3,4,5,6,7} Seven eigenvalues correspond to seven control modes
-# respectively
-# Duty cycle mode: 0
-# Current loop mode: 1
-# Current brake mode: 2
-# Velocity mode: 3
-# Position mode: 4
-# Set origin mode:5
-# Position velocity loop mode :6
-# Parameter dictionary for each specific motor that can be controlled with this library
-# Thresholds are in the datasheet for the motor on cubemars.com
-# Verified Error codes for servo motor
+from opensourceleg.actuators.base import (
+    CONTROL_MODE_CONFIGS,
+    CONTROL_MODES,
+    MOTOR_CONSTANTS,
+    ActuatorBase,
+    ControlModeConfig,
+    ControlGains,
+)
+from opensourceleg.actuators.decorators import (
+    check_actuator_connection,
+    check_actuator_open,
+    check_actuator_stream,
+)
+from opensourceleg.math import ThermalModel
+from opensourceleg.utilities import SoftRealtimeLoop
+from opensourceleg.logging.logger import LOGGER
 
-Servo_Params = {
-        'ERROR_CODES':{
-            0 : 'No Error',
-            1 : 'Over voltage fault',           # FAULT_CODE_OVER_VOLTAGE
-            2 : 'Under voltage fault',          # FAULT_CODE_UNDER_VOLTAGE  
-            3 : 'DRV fault',                    # FAULT_CODE_DRV
-            4 : 'Absolute over current fault',  # FAULT_CODE_ABS_OVER_CURRENT
-            5 : 'Over temp FET fault',          # FAULT_CODE_OVER_TEMP_FET
-            6 : 'Over temp motor fault',        # FAULT_CODE_OVER_TEMP_MOTOR
-            7 : 'Gate driver over voltage fault', # FAULT_CODE_GATE_DRIVER_OVER_VOLTAGE
-            8 : 'Gate driver under voltage fault', # FAULT_CODE_GATE_DRIVER_UNDER_VOLTAGE
-            9 : 'MCU under voltage fault',      # FAULT_CODE_MCU_UNDER_VOLTAGE
-            10: 'Booting from watchdog reset fault', # FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET
-            11: 'Encoder SPI fault',            # FAULT_CODE_ENCODER_SPI
-            12: 'Encoder sincos below min amplitude fault', # FAULT_CODE_ENCODER_SINCOS_BELOW_MIN_AMPLITUDE
-            13: 'Encoder sincos above max amplitude fault', # FAULT_CODE_ENCODER_SINCOS_ABOVE_MAX_AMPLITUDE
-            14: 'Flash corruption fault',       # FAULT_CODE_FLASH_CORRUPTION
-            15: 'High offset current sensor 1 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_1
-            16: 'High offset current sensor 2 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_2
-            17: 'High offset current sensor 3 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_3
-            18: 'Unbalanced currents fault'     # FAULT_CODE_UNBALANCED_CURRENTS
-        },
-        'AK10-9':{
-            'P_min' : -360000000,  # -36000 deg (based on protocol doc)
-            'P_max' : 360000000,   # 36000 deg (based on protocol doc)
-            'V_min' : -100000,     # -100000 ERPM electrical speed
-            'V_max' : 100000,      # 100000 ERPM electrical speed
-            'Curr_min': -60000,    # -60A (protocol doc: -60000-60000 represents -60A-60A)
-            'Curr_max': 60000,     # 60A (protocol doc: -60000-60000 represents -60A-60A)
-            'T_min' : -15,         # NM
-            'T_max' : 15,          # NM
-            'Temp_min': -20,       # -20°C (based on protocol doc)
-            'Temp_max': 127,       # 127°C (based on protocol doc)
-            'Kt_TMotor' : 0.16,    # from TMotor website (actually 1/Kvll)
-            'Current_Factor' : 0.59, # UNTESTED CONSTANT!
-            'Kt_actual': 0.206,    # UNTESTED CONSTANT!
-            'GEAR_RATIO': 9.0, 
-            'NUM_POLE_PAIRS': 21,
-            'Use_derived_torque_constants': False, # true if you have a better model
-        },
-        'AK80-9':{
-            'P_min' : -360000000,  # -36000 deg (based on protocol doc)
-            'P_max' : 360000000,   # 36000 deg (based on protocol doc)
-            'V_min' : -100000,     # -100000 ERPM electrical speed (same as AK10-9)
-            'V_max' : 100000,      # 100000 ERPM electrical speed (same as AK10-9)
-            'Curr_min': -60000,    # -60A (protocol doc: -60000-60000 represents -60A-60A)
-            'Curr_max': 60000,     # 60A (protocol doc: -60000-60000 represents -60A-60A)
-            'T_min' : -30,         # NM
-            'T_max' : 30,          # NM
-            'Temp_min': -20,       # -20°C (based on protocol doc)
-            'Temp_max': 127,       # 127°C (based on protocol doc)
-            'Kt_TMotor' : 0.091,   # from TMotor website (actually 1/Kvll)
-            'Current_Factor' : 0.59,
-            'Kt_actual': 0.115,
-            'GEAR_RATIO': 9.0, 
-            'NUM_POLE_PAIRS': 21,
-            'Use_derived_torque_constants': False, # true if you have a better model
-        },
-        'CAN_PACKET_ID':{
-            'CAN_PACKET_SET_DUTY':0,        # Motor runs in duty cycle mode
-            'CAN_PACKET_SET_CURRENT':1,     # Motor runs in current loop mode
-            'CAN_PACKET_SET_CURRENT_BRAKE':2, # Motor current brake mode operation
-            'CAN_PACKET_SET_RPM':3,         # Motor runs in velocity mode
-            'CAN_PACKET_SET_POS':4,         # Motor runs in position loop mode
-            'CAN_PACKET_SET_ORIGIN_HERE':5, # Set origin mode
-            'CAN_PACKET_SET_POS_SPD':6,     # Position velocity loop mode
-        },
+
+# TMotor servo mode constants
+TMOTOR_SERVO_CONSTANTS = MOTOR_CONSTANTS(
+    MOTOR_COUNT_PER_REV=3600,  # 360 degrees * 10 (0.1 degree resolution)
+    NM_PER_AMP=0.115,  # Approximate for AK80-9
+    NM_PER_RAD_TO_K=0.0,  # Servo mode handles stiffness differently
+    NM_S_PER_RAD_TO_B=0.0,  # Servo mode handles damping differently
+    MAX_CASE_TEMPERATURE=80.0,
+    MAX_WINDING_TEMPERATURE=110.0,
+)
+
+
+@dataclass
+class ServoMotorParams:
+    """Parameters for TMotor servo mode configuration."""
+    P_min: float
+    P_max: float
+    V_min: float
+    V_max: float
+    Curr_min: float
+    Curr_max: float
+    T_min: float
+    T_max: float
+    Temp_min: float
+    Temp_max: float
+    Kt_actual: float
+    GEAR_RATIO: float
+    NUM_POLE_PAIRS: int
+
+
+# Servo motor parameters dictionary
+SERVO_PARAMS: Dict[str, Any] = {
+    'ERROR_CODES': {
+        0: 'No Error',
+        1: 'Over voltage fault',
+        2: 'Under voltage fault',
+        3: 'DRV fault',
+        4: 'Absolute over current fault',
+        5: 'Over temp FET fault',
+        6: 'Over temp motor fault',
+        7: 'Gate driver over voltage fault',
+        8: 'Gate driver under voltage fault',
+        9: 'MCU under voltage fault',
+        10: 'Booting from watchdog reset fault',
+        11: 'Encoder SPI fault',
+        12: 'Encoder sincos below min amplitude fault',
+        13: 'Encoder sincos above max amplitude fault',
+        14: 'Flash corruption fault',
+        15: 'High offset current sensor 1 fault',
+        16: 'High offset current sensor 2 fault',
+        17: 'High offset current sensor 3 fault',
+        18: 'Unbalanced currents fault'
+    },
+    'AK10-9': {
+        'P_min': -32000,      # -3200 deg (0.1 deg resolution: -32000 * 0.1 = -3200)
+        'P_max': 32000,       # 3200 deg (0.1 deg resolution: 32000 * 0.1 = 3200)
+        'V_min': -100000,     # -100000 ERPM electrical speed
+        'V_max': 100000,      # 100000 ERPM electrical speed
+        'Curr_min': -60000,   # -60A (protocol: -60000 = -60A, 1000 = 1A)
+        'Curr_max': 60000,    # 60A (protocol: 60000 = 60A, 1000 = 1A)
+        'T_min': -15,         # NM
+        'T_max': 15,          # NM
+        'Temp_min': -20,      # -20°C (based on protocol doc)
+        'Temp_max': 127,      # 127°C (based on protocol doc)
+        'Kt_TMotor': 0.16,    # from TMotor website (actually 1/Kvll)
+        'Current_Factor': 0.59, # UNTESTED CONSTANT!
+        'Kt_actual': 0.206,   # UNTESTED CONSTANT!
+        'GEAR_RATIO': 9.0,
+        'NUM_POLE_PAIRS': 21,
+        'Use_derived_torque_constants': False, # true if you have a better model
+    },
+    'AK80-9': {
+        'P_min': -32000,      # -3200 deg (0.1 deg resolution: -32000 * 0.1 = -3200)
+        'P_max': 32000,       # 3200 deg (0.1 deg resolution: 32000 * 0.1 = 3200)
+        'V_min': -32000,      # -320000 rpm electrical speed (note: different from AK10-9)
+        'V_max': 32000,       # 320000 rpm electrical speed (note: different from AK10-9)
+        'Curr_min': -60000,   # -60A (protocol: -60000 = -60A, 1000 = 1A)
+        'Curr_max': 60000,    # 60A (protocol: 60000 = 60A, 1000 = 1A)
+        'T_min': -30,         # NM
+        'T_max': 30,          # NM
+        'Temp_min': -20,      # -20°C (based on protocol doc)
+        'Temp_max': 127,      # 127°C (based on protocol doc)
+        'Kt_TMotor': 0.091,   # from TMotor website (actually 1/Kvll)
+        'Current_Factor': 0.59,
+        'Kt_actual': 0.115,
+        'GEAR_RATIO': 9.0,
+        'NUM_POLE_PAIRS': 21,
+        'Use_derived_torque_constants': False, # true if you have a better model
+    },
+    'CAN_PACKET_ID': {
+        'CAN_PACKET_SET_DUTY': 0,        # Motor runs in duty cycle mode
+        'CAN_PACKET_SET_CURRENT': 1,     # Motor runs in current loop mode
+        'CAN_PACKET_SET_CURRENT_BRAKE': 2, # Motor current brake mode operation
+        'CAN_PACKET_SET_RPM': 3,         # Motor runs in velocity mode
+        'CAN_PACKET_SET_POS': 4,         # Motor runs in position loop mode
+        'CAN_PACKET_SET_ORIGIN_HERE': 5, # Set origin mode
+        'CAN_PACKET_SET_POS_SPD': 6,     # Position velocity loop mode
+    },
 }
-"""
-A dictionary with the parameters needed to control the motor
-"""
 
-class servo_motor_state:
-    """Data structure to store and update motor states"""
-    def __init__(self,position, velocity, current, temperature, error, acceleration):
-        """
-        Sets the motor state to the input.
 
-        Args:
-            position: Position in rad
-            velocity: Velocity in rad/s
-            current: current in amps
-            temperature: temperature in degrees C
-            error: error code, 0 means no error
-            acceleration: acceleration in rad/s
-        """
-        self.set_state(position, velocity, current, temperature, error, acceleration)
+class ServoControlMode(Enum):
+    """Internal servo control modes for TMotor communication."""
+    DUTY_CYCLE = 0
+    CURRENT_LOOP = 1
+    CURRENT_BRAKE = 2
+    VELOCITY = 3
+    POSITION = 4
+    SET_ORIGIN = 5
+    POSITION_VELOCITY = 6
+    IDLE = 7
 
-    def set_state(self, position, velocity, current, temperature, error, acceleration):
-        """
-        Sets the motor state to the input.
 
-        Args:
-            position: Position in rad
-            velocity: Velocity in rad/s
-            current: current in amps
-            temperature: temperature in degrees C
-            error: error code, 0 means no error
-            acceleration: acceleration in rad/s
-        """
+@dataclass
+class ServoMotorState:
+    """Data structure to store servo motor state information."""
+    position: float = 0.0
+    velocity: float = 0.0
+    current: float = 0.0
+    temperature: float = 0.0
+    error: int = 0
+    acceleration: float = 0.0
+
+    def set_state(self, position: float, velocity: float, current: float, 
+                  temperature: float, error: int, acceleration: float) -> None:
+        """Update all state values."""
         self.position = position
         self.velocity = velocity
         self.current = current
@@ -127,485 +161,347 @@ class servo_motor_state:
         self.error = error
         self.acceleration = acceleration
 
-    def set_state_obj(self, other_motor_state):
-        """
-        Sets this motor state object's values to those of another motor state object.
+    def set_state_obj(self, other_state: 'ServoMotorState') -> None:
+        """Copy state from another ServoMotorState object."""
+        self.position = other_state.position
+        self.velocity = other_state.velocity
+        self.current = other_state.current
+        self.temperature = other_state.temperature
+        self.error = other_state.error
+        self.acceleration = other_state.acceleration
 
-        Args:
-            other_motor_state: The other motor state object with values to set this motor state object's values to.
-        """
-        self.position = other_motor_state.position
-        self.velocity = other_motor_state.velocity
-        self.current = other_motor_state.current
-        self.temperature = other_motor_state.temperature
-        self.error = other_motor_state.error
-        self.acceleration = other_motor_state.acceleration
 
-    def __str__(self):
-        return (
-            f'Position: {self.position} | Velocity: {self.velocity} | '
-            f'Current: {self.current} | Temperature: {self.temperature} | Error: {self.error}'
-        )
+@dataclass
+class ServoCommand:
+    """Data structure to store servo commands."""
+    position: float = 0.0
+    velocity: float = 0.0
+    current: float = 0.0
+    duty: float = 0.0
+    acceleration: float = 0.0
 
-class servo_command:
-    """Data structure to store Servo command that will be sent upon update"""
-    def __init__(self, position, velocity, current, duty, acceleration):
-        """
-        Sets the motor state to the input.
 
-        Args:
-            position: Position in deg
-            velocity: Velocity in ERPM
-            current: Current in amps
-            duty: Duty cycle in percentage ratio (-1 to 1)
-            acceleration: acceleration in ERPMs
-        """
-        self.position = position
-        self.velocity = velocity
-        self.current = current
-        self.duty = duty
-        self.acceleration = acceleration
-
-# # motor state from the controller, uneditable named tuple
-# servo_motor_state = namedtuple('motor_state', 'position velocity current temperature error')
-# """
-# Motor state from the controller, uneditable named tuple
-# """
-
-# python-can listener object, with handler to be called upon reception of a message on the CAN bus
-class motorListener(can.Listener):
-    """Python-can listener object, with handler to be called upon reception of a message on the CAN bus"""
-    def __init__(self, canman, motor):
-        """
-        Sets stores can manager and motor object references
-        
-        Args:
-            canman: The CanManager object to get messages from
-            motor: The TMotorCANManager object to update
-        """
-        self.canman = canman
-        self.bus = canman.bus
-        self.motor = motor
-
-    def on_message_received(self, msg):
-        """
-        Updates this listener's motor with the info contained in msg, if that message was for this motor.
-
-        args:
-            msg: A python-can CAN message
-        """
-        data = bytes(msg.data)
-        ID = msg.arbitration_id & 0x00000FF
-        if ID == self.motor.ID:
-            self.motor._update_state_async(self.canman.parse_servo_message(data))
-
-# A class to manage the low level CAN communication protocols
-class CAN_Manager_servo(object):
-    """A class to manage the low level CAN communication protocols"""
-    debug = False
-    """
-    Set to true to display every message sent and received for debugging.
-    """
-    _instance = None
-    """
-    Used to keep track of one instantiation of the class to make a singleton object
-    """
+class CANManagerServo:
+    """Singleton CAN manager for servo mode communication."""
     
-    def __new__(cls):
-        """
-        Makes a singleton object to manage socketcan CAN bus for Raspberry Pi.
-        """
+    _instance: Optional['CANManagerServo'] = None
+    _initialized: bool = False
+    debug: bool = False
+    """Set to true to display every message sent and received for debugging."""
+
+    def __new__(cls) -> 'CANManagerServo':
+        """Ensure singleton pattern."""
         if not cls._instance:
-            cls._instance = super(CAN_Manager_servo, cls).__new__(cls)
-            cls._instance._initialized = False
+            cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __init__(self):
-        """
-        Initialize CAN bus connection for Raspberry Pi
-        """
+    def __init__(self) -> None:
+        """Initialize CAN bus connection."""
         if self._initialized:
             return
-            
-        print("Initializing CAN Manager for Raspberry Pi")
+        
+        LOGGER.info("Initializing CAN Manager for TMotor Servo Mode")
         
         try:
-            # Configure CAN interface
-            os.system('sudo /sbin/ip link set can0 down')  # noqa: S605,S607
-            os.system('sudo /sbin/ip link set can0 up type can bitrate 1000000')  # noqa: S605,S607
-            os.system('sudo ifconfig can0 txqueuelen 1000')  # noqa: S605,S607
+            # Configure CAN interface for Linux/RPi
+            os.system('sudo /sbin/ip link set can0 down')
+            os.system('sudo /sbin/ip link set can0 up type can bitrate 1000000')
+            os.system('sudo ifconfig can0 txqueuelen 1000')
             
-            # Create CAN bus object using socketcan (standard for Linux/RPi)
             self.bus = can.interface.Bus(channel='can0', bustype='socketcan')
-            # Create notifier for message handling
             self.notifier = can.Notifier(bus=self.bus, listeners=[])
             
-            print("Connected on: " + str(self.bus))
+            LOGGER.info(f"CAN bus connected: {self.bus}")
             self._initialized = True
             
         except Exception as e:
-            print(f"CAN bus initialization failed: {e}")
-            print("Make sure:")
-            print("1. CAN interface is available (sudo ip link show can0)")
-            print("2. User has sudo privileges")
-            print("3. can-utils is installed (sudo apt install can-utils)")
+            LOGGER.error(f"CAN bus initialization failed: {e}")
             raise RuntimeError("CAN bus initialization failed") from e
 
-    def __del__(self):
-        """
-        # shut down the CAN bus when the object is deleted
-        # This may not ever get called, so keep a reference and explicitly delete if this is important.
-        """
-        os.system('sudo /sbin/ip link set can0 down')  # noqa: S605,S607 
+    def __del__(self) -> None:
+        """Clean up CAN interface."""
+        try:
+            os.system('sudo /sbin/ip link set can0 down')
+        except Exception as e:
+            LOGGER.warning(f"Error shutting down CAN interface: {e}")
 
-    # subscribe a motor object to the CAN bus to be updated upon message reception
-    def add_motor(self, motor):
-        """
-        Subscribe a motor object to the CAN bus to be updated upon message reception
+    def add_motor(self, motor: 'TMotorServoActuator') -> None:
+        """Add a motor to the CAN listener."""
+        listener = MotorListener(self, motor)
+        self.notifier.add_listener(listener)
 
-        Args:
-            motor: The TMotorManager object to be subscribed to the notifier
-        """
-        self.notifier.add_listener(motorListener(self, motor))
-
-#* Buffer information for servo mode data manipulation
-
-#******************START****************************#
-    # Simplified buffer functions for servo mode data manipulation
-    @staticmethod
-    def pack_int16(number):
-        """Pack 16-bit integer into byte list"""
-        return [(number >> 8) & 0xFF, number & 0xFF]
-    
-    @staticmethod
-    def pack_uint16(number):
-        """Pack unsigned 16-bit integer into byte list"""
-        return [(number >> 8) & 0xFF, number & 0xFF]
-       
-    @staticmethod
-    def pack_int32(number):
-        """Pack 32-bit integer into byte list"""
-        return [(number >> 24) & 0xFF, (number >> 16) & 0xFF, 
-                (number >> 8) & 0xFF, number & 0xFF]
-
-    @staticmethod
-    def pack_uint32(number):
-        """Pack unsigned 32-bit integer into byte list"""
-        return [(number >> 24) & 0xFF, (number >> 16) & 0xFF, 
-                (number >> 8) & 0xFF, number & 0xFF]
-
-    # Legacy methods for backward compatibility
-    @staticmethod
-    def buffer_append_int16(buffer, number, index=None):
-        """Legacy method - use pack_int16() instead"""
-        buffer.extend(CAN_Manager_servo.pack_int16(number))
-    
-    @staticmethod
-    def buffer_append_uint16(buffer, number, index=None):
-        """Legacy method - use pack_uint16() instead"""
-        buffer.extend(CAN_Manager_servo.pack_uint16(number))
-       
-    @staticmethod
-    def buffer_append_int32(buffer, number, index=None):
-        """Legacy method - use pack_int32() instead"""
-        buffer.extend(CAN_Manager_servo.pack_int32(number))
-
-    @staticmethod
-    def buffer_append_uint32(buffer, number, index=None):
-        """Legacy method - use pack_uint32() instead"""
-        buffer.extend(CAN_Manager_servo.pack_uint32(number))
-
-    # Buffer allocation for 64 bit
-    @staticmethod
-    def buffer_append_int64(buffer, number, index=None):
-        """
-        buffer size for int 64
-
-        Args:
-            Buffer: memory allocated to store data.
-            number: value.
-            index: optional index pointer (for compatibility)
-        """
-        buffer.append((number >> 56) & 0xFF)
-        buffer.append((number >> 48) & 0xFF)
-        buffer.append((number >> 40) & 0xFF)
-        buffer.append((number >> 32) & 0xFF)
-        buffer.append((number >> 24) & 0xFF)
-        buffer.append((number >> 16) & 0xFF)
-        buffer.append((number >> 8) & 0xFF)
-        buffer.append(number & 0xFF)
-
-    # Buffer allocation for Unsigned 64 bit
-    @staticmethod
-    def buffer_append_uint64(buffer, number, index=None):
-        """
-        buffer size for uint 64
-
-        Args:
-            Buffer: memory allocated to store data.
-            number: value.
-            index: optional index pointer (for compatibility)
-        """
-        buffer.append((number >> 56) & 0xFF)
-        buffer.append((number >> 48) & 0xFF)
-        buffer.append((number >> 40) & 0xFF)
-        buffer.append((number >> 32) & 0xFF)
-        buffer.append((number >> 24) & 0xFF)
-        buffer.append((number >> 16) & 0xFF)
-        buffer.append((number >> 8) & 0xFF)
-        buffer.append(number & 0xFF)
-
-
-#******************END****************************#
-
-#* Sends data via CAN
-    # sends a message to the motor (when the motor is in Servo mode)
-    def send_servo_message(self, motor_id, data,data_len):
-        """
-        Sends a Servo Mode message to the motor, with a header of motor_id and data array of data
-
-        Args:
-            motor_id: The CAN ID of the motor to send to.
-            data: An array of integers or bytes of data to send.
-        """
-        DLC = data_len
-        if DLC > 8:
+    def send_message(self, motor_id: int, data: list, data_len: int) -> None:
+        """Send CAN message to motor."""
+        if data_len > 8:
             raise ValueError(f'Data too long in message for motor {motor_id}')
         
         if self.debug:
-            print('ID: ' + str(hex(motor_id)) + '   Data: ' + '[{}]'.format(', '.join(hex(d) for d in data)) )
+            LOGGER.info(f'ID: {hex(motor_id)}   Data: [{", ".join(hex(d) for d in data)}]')
         
         message = can.Message(arbitration_id=motor_id, data=data, is_extended_id=True)
-
+        
         try:
             self.bus.send(message)
             if self.debug:
-                print("    Message sent on " + str(self.bus.channel_info) )
+                LOGGER.info(f"Message sent on {self.bus.channel_info}")
         except can.CanError as e:
             if self.debug:
-                print("    Message NOT sent: " + e.message)
+                LOGGER.error(f"Message NOT sent: {e}")
+            else:
+                LOGGER.error(f"Failed to send CAN message: {e}")
 
-    # send the power on code
-    def power_on(self, motor_id):
-        """
-        Sends the power on code to motor_id.
+    def power_on(self, motor_id: int) -> None:
+        """Send power on command."""
+        self.send_message(motor_id, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFC], 8)
 
-        Args:
-            motor_id: The CAN ID of the motor to send the message to.
-            Data: This is obtained from the datasheet.
-        """
+    def power_off(self, motor_id: int) -> None:
+        """Send power off command."""
+        self.send_message(motor_id, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFD], 8)
 
-        self.send_servo_message(motor_id, [ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0XFC], 8)
-        
-    # send the power off code
-    def power_off(self, motor_id):
-        """
-        Sends the power off code to motor_id.
+    def set_current(self, controller_id: int, current: float) -> None:
+        """Send current control command."""
+        # Convert current to protocol format: -60000 to 60000 represents -60A to 60A
+        # So 1A = 1000 in protocol units (as per protocol documentation)
+        current_protocol = int(current * 1000.0)
+        buffer = self._pack_int32(current_protocol)
+        message_id = controller_id | (SERVO_PARAMS['CAN_PACKET_ID']['CAN_PACKET_SET_CURRENT'] << 8)
+        self.send_message(message_id, buffer, len(buffer))
 
-        Args:
-            motor_id: The CAN ID of the motor to send the message to.
-        """
-        self.send_servo_message(motor_id, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0XFD], 8)
+    def set_current_brake(self, controller_id: int, current: float) -> None:
+        """Send current brake control command."""
+        # Convert current to protocol format: -60000 to 60000 represents -60A to 60A
+        # So 1A = 1000 in protocol units (as per protocol documentation)
+        current_protocol = int(current * 1000.0)
+        buffer = self._pack_int32(current_protocol)
+        message_id = controller_id | (SERVO_PARAMS['CAN_PACKET_ID']['CAN_PACKET_SET_CURRENT_BRAKE'] << 8)
+        self.send_message(message_id, buffer, len(buffer))
 
+    def set_velocity(self, controller_id: int, velocity: float) -> None:
+        """Send velocity control command."""
+        buffer = self._pack_int32(int(velocity))
+        message_id = controller_id | (SERVO_PARAMS['CAN_PACKET_ID']['CAN_PACKET_SET_RPM'] << 8)
+        self.send_message(message_id, buffer, len(buffer))
 
-#* Code for the working of different modes in servo mode. 
-   
-    #* ********************START*******************************************#
-    #TODO: Controller id vs motorID
-    # Send Servo control message for duty cycle mode
-    #*Duty cycle mode: duty cycle voltage is specified for a given motor, similar to squarewave drive mode
-    def comm_can_set_duty(self, controller_id, duty):
-        """
-        Send a servo control message for duty cycle mode
+    def set_position(self, controller_id: int, position: float) -> None:
+        """Send position control command."""
+        buffer = self._pack_int32(int(position * 10.0))  # Position in degrees * 10 (0.1 deg resolution)
+        message_id = controller_id | (SERVO_PARAMS['CAN_PACKET_ID']['CAN_PACKET_SET_POS'] << 8)
+        self.send_message(message_id, buffer, len(buffer))
 
-        Args:
-            controller_id: CAN ID of the motor to send the message to
-            duty: duty cycle (-1 to 1) to use
-        """
+    def set_position_velocity(self, controller_id: int, position: float, 
+                            velocity: float, acceleration: float) -> None:
+        """Send position control with velocity profile."""
         buffer = []
-        self.buffer_append_int32(buffer, np.int32(duty * 100000.0))
-        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_DUTY'] << 8)
-        self.send_servo_message(message_id, buffer, len(buffer))
+        buffer.extend(self._pack_int32(int(position * 10.0)))  # Position in degrees * 10 (0.1 deg resolution)
+        buffer.extend(self._pack_int16(int(velocity / 10.0)))
+        buffer.extend(self._pack_int16(int(acceleration / 10.0)))
+        message_id = controller_id | (SERVO_PARAMS['CAN_PACKET_ID']['CAN_PACKET_SET_POS_SPD'] << 8)
+        self.send_message(message_id, buffer, len(buffer))
 
-    # Send Servo control message for current loop mode
-    # *Current loop mode: given the Iq current specified by the motor, 
-    # the motor output torque = Iq *KT, so it can be used as a torque loop
-    def comm_can_set_current(self, controller_id, current):
-        """
-        Send a servo control message for current loop mode
+    def set_origin(self, controller_id: int, mode: int = 1) -> None:
+        """Set motor origin/zero position."""
+        buffer = [mode]
+        message_id = controller_id | (SERVO_PARAMS['CAN_PACKET_ID']['CAN_PACKET_SET_ORIGIN_HERE'] << 8)
+        self.send_message(message_id, buffer, len(buffer))
 
-        Args:
-            controller_id: CAN ID of the motor to send the message to
-            current: current in Amps to use (-60 to 60)
-        """
-        buffer = []
-        self.buffer_append_int32(buffer, np.int32(current * 1000.0))
-        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_CURRENT'] << 8)
-        self.send_servo_message(message_id, buffer, len(buffer))
+    def set_duty_cycle(self, controller_id: int, duty: float) -> None:
+        """Send duty cycle command."""
+        buffer = self._pack_int32(int(duty * 100000.0))
+        message_id = controller_id | (SERVO_PARAMS['CAN_PACKET_ID']['CAN_PACKET_SET_DUTY'] << 8)
+        self.send_message(message_id, buffer, len(buffer))
 
-    # Send Servo control message for current brake mode
-    # *Current brake mode: the motor is fixed at the current position by the specified brake
-    # current given by the motor (pay attention to the motor temperature when using)
-    def comm_can_set_cb(self, controller_id, current):
-        """
-        Send a servo control message for current brake mode
+    @staticmethod
+    def _pack_int16(number: int) -> list:
+        """Pack 16-bit integer into byte list."""
+        return [(number >> 8) & 0xFF, number & 0xFF]
 
-        Args:
-            controller_id: CAN ID of the motor to send the message to
-            current: current in Amps to use (0 to 60)
-        """
-        buffer = []
-        self.buffer_append_int32(buffer, np.int32(current * 1000.0))
-        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_CURRENT_BRAKE'] << 8)
-        self.send_servo_message(message_id, buffer, len(buffer))
-        
-    # Send Servo control message for Velocity mode
-    #*Velocity mode: the speed specified by the given motor
-    def comm_can_set_rpm(self, controller_id, rpm):
-        """
-        Send a servo control message for velocity control mode
+    @staticmethod
+    def _pack_int32(number: int) -> list:
+        """Pack 32-bit integer into byte list."""
+        return [(number >> 24) & 0xFF, (number >> 16) & 0xFF, 
+                (number >> 8) & 0xFF, number & 0xFF]
 
-        Args:
-            controller_id: CAN ID of the motor to send the message to
-            rpm: velocity in ERPM (-100000 to 100000)
-        """
-        buffer = []
-        self.buffer_append_int32(buffer, np.int32(rpm))
-        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_RPM'] << 8)
-        self.send_servo_message(message_id, buffer, len(buffer))
-    
-    # Send Servo control message for Position Loop mode
-    # *Position mode: Given the specified position of the motor, the motor will run to the
-    # specified position, (default speed 12000erpm acceleration 40000erpm)
-    def comm_can_set_pos(self, controller_id, pos):
-        """
-        Send a servo control message for position control mode
-
-        Args:
-            controller_id: CAN ID of the motor to send the message to
-            pos: desired position in degrees
-        """
-        buffer = []
-        # Use 10000.0 to match Arduino implementation, not 1000000.0 from protocol doc
-        self.buffer_append_int32(buffer, np.int32(pos * 10000.0))
-        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_POS'] << 8)
-        self.send_servo_message(message_id, buffer, len(buffer))
-    
-    #Set origin mode
-    # *0 means setting the temporary origin (power failure elimination), 
-    # 1 means setting the permanent zero point (automatic parameter saving), 
-    # 2 means restoring the default zero point (automatic parameter saving)
-    def comm_can_set_origin(self, controller_id, set_origin_mode):
-        """
-        set the origin
-
-        Args:
-            controller_id: CAN ID of the motor to send the message to
-            set_origin_mode: 0 means setting the temporary origin (power failure elimination), 
-                1 means setting the permanent zero point (automatic parameter saving), 
-                2 means restoring the default zero point (automatic parameter saving)
-        """
-        buffer = [set_origin_mode]
-        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_ORIGIN_HERE'] << 8)
-        self.send_servo_message(message_id, buffer, len(buffer))
-
-    #Position and Velocity Loop Mode
-    #* Check documentation
-    def comm_can_set_pos_spd(self, controller_id, pos, spd, RPA):
-        """
-        Send a servo control message for position control mode, with specified velocity and acceleration
-        This will be a trapezoidal speed profile.
-
-        Args:
-            controller_id: CAN ID of the motor to send the message to
-            pos: desired position in degrees
-            spd: desired max speed in ERPM
-            RPA: desired acceleration in ERPM/s
-        """
-        buffer = []
-        # Match Arduino implementation: pos * 10000.0, spd/10, RPA/10
-        self.buffer_append_int32(buffer, np.int32(pos * 10000.0))
-        self.buffer_append_int16(buffer, np.int16(spd / 10.0))
-        self.buffer_append_int16(buffer, np.int16(RPA / 10.0))
-        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_POS_SPD'] << 8)
-        self.send_servo_message(message_id, buffer, len(buffer))
-
-    #* **************************END************************************************#
- 
-
-
-#*****************Parsing message data********************************#
-    def parse_servo_message(self, data):
-        """
-        Unpack the servo message into a servo_motor_state object
-
-        Args:
-            data: bytes of the message to be processed
-
-        Returns:
-            A servo_motor_state object representing the state based on the data received.
-        """
-        # using numpy to convert signed/unsigned integers
-        pos_int = np.int16(data[0] << 8 | data[1])
-        spd_int = np.int16(data[2] << 8 | data[3])
-        cur_int = np.int16(data[4] << 8 | data[5])
-        motor_pos= float( pos_int * 0.1) # motor position
-        motor_spd= float( spd_int * 10.0) # motor speed
-        motor_cur= float( cur_int * 0.01) # motor current
-        motor_temp= np.int16(data[6])  # motor temperature
-        motor_error= data[7] # motor error mode
-        if self.debug:
-            print(data)
-            print('  Position: ' + str(motor_pos))
-            print('  Velocity: ' + str(motor_spd))
-            print('  Current: ' + str(motor_cur))
-            print('  Temp: ' + str(motor_temp))
-            print('  Error: ' + str(motor_error))
+    def parse_servo_message(self, data: bytes) -> ServoMotorState:
+        """Parse received servo message into motor state."""
+        if len(data) < 8:
+            raise ValueError(f"Invalid message length: {len(data)}")
             
-        return servo_motor_state(motor_pos, motor_spd,motor_cur,motor_temp, motor_error, 0)
+        # Parse according to TMotor servo protocol
+        pos_int = int.from_bytes(data[0:2], byteorder='little', signed=True)
+        spd_int = int.from_bytes(data[2:4], byteorder='little', signed=True)
+        cur_int = int.from_bytes(data[4:6], byteorder='little', signed=True)
+        
+        motor_pos = float(pos_int * 0.1)  # Position in degrees (0.1 deg resolution)
+        motor_spd = float(spd_int * 10.0)  # Speed in ERPM
+        motor_cur = float(cur_int / 1000.0)  # Current in amps (protocol: 1000 = 1A)
+        motor_temp = float(data[6])  # Temperature in Celsius
+        motor_error = int(data[7])  # Error code
+        
+        if self.debug:
+            LOGGER.info(f"Position: {motor_pos}")
+            LOGGER.info(f"Velocity: {motor_spd}")
+            LOGGER.info(f"Current: {motor_cur}")
+            LOGGER.info(f"Temp: {motor_temp}")
+            LOGGER.info(f"Error: {motor_error}")
+            
+        return ServoMotorState(motor_pos, motor_spd, motor_cur, motor_temp, motor_error, 0.0)
 
 
-# default variables to be logged
+class MotorListener(can.Listener):
+    """CAN message listener for motor updates."""
+    
+    def __init__(self, canman: CANManagerServo, motor: 'TMotorServoActuator') -> None:
+        """Initialize listener."""
+        self.canman = canman
+        self.motor = motor
+
+    def on_message_received(self, msg: can.Message) -> None:
+        """Handle received CAN message."""
+        data = bytes(msg.data)
+        motor_id = msg.arbitration_id & 0x00000FF
+        if motor_id == self.motor.ID:
+            self.motor._update_state_async(self.canman.parse_servo_message(data))
+
+
+def _servo_position_mode_entry(actuator: 'TMotorServoActuator') -> None:
+    """Entry callback for position mode."""
+    actuator._servo_mode = ServoControlMode.POSITION
+
+
+def _servo_position_mode_exit(actuator: 'TMotorServoActuator') -> None:
+    """Exit callback for position mode."""
+    if not actuator.is_offline:
+        actuator._canman.set_duty_cycle(actuator.ID, 0.0)
+
+
+def _servo_current_mode_entry(actuator: 'TMotorServoActuator') -> None:
+    """Entry callback for current mode."""
+    actuator._servo_mode = ServoControlMode.CURRENT_LOOP
+
+
+def _servo_current_mode_exit(actuator: 'TMotorServoActuator') -> None:
+    """Exit callback for current mode."""
+    if not actuator.is_offline:
+        actuator._canman.set_current(actuator.ID, 0.0)
+
+
+def _servo_velocity_mode_entry(actuator: 'TMotorServoActuator') -> None:
+    """Entry callback for velocity mode."""
+    actuator._servo_mode = ServoControlMode.VELOCITY
+
+
+def _servo_velocity_mode_exit(actuator: 'TMotorServoActuator') -> None:
+    """Exit callback for velocity mode."""
+    if not actuator.is_offline:
+        actuator._canman.set_velocity(actuator.ID, 0.0)
+
+
+def _servo_impedance_mode_entry(actuator: 'TMotorServoActuator') -> None:
+    """Entry callback for impedance mode (using position control)."""
+    actuator._servo_mode = ServoControlMode.POSITION_VELOCITY
+
+
+def _servo_impedance_mode_exit(actuator: 'TMotorServoActuator') -> None:
+    """Exit callback for impedance mode."""
+    if not actuator.is_offline:
+        actuator._canman.set_duty_cycle(actuator.ID, 0.0)
+
+
+def _servo_idle_mode_entry(actuator: 'TMotorServoActuator') -> None:
+    """Entry callback for idle mode."""
+    actuator._servo_mode = ServoControlMode.IDLE
+
+
+def _servo_idle_mode_exit(actuator: 'TMotorServoActuator') -> None:
+    """Exit callback for idle mode."""
+    if not actuator.is_offline:
+        actuator._canman.set_duty_cycle(actuator.ID, 0.0)
+
+
+TMOTOR_SERVO_CONTROL_MODE_CONFIGS = CONTROL_MODE_CONFIGS(
+    POSITION=ControlModeConfig(
+        entry_callback=_servo_position_mode_entry,
+        exit_callback=_servo_position_mode_exit,
+        has_gains=True,
+        max_gains=ControlGains(kp=1000.0, ki=100.0, kd=10.0, k=0.0, b=0.0, ff=0.0),
+    ),
+    CURRENT=ControlModeConfig(
+        entry_callback=_servo_current_mode_entry,
+        exit_callback=_servo_current_mode_exit,
+        has_gains=True,
+        max_gains=ControlGains(kp=100.0, ki=1000.0, kd=0.0, k=0.0, b=0.0, ff=100.0),
+    ),
+    VELOCITY=ControlModeConfig(
+        entry_callback=_servo_velocity_mode_entry,
+        exit_callback=_servo_velocity_mode_exit,
+        has_gains=True,
+        max_gains=ControlGains(kp=0.0, ki=0.0, kd=50.0, k=0.0, b=0.0, ff=0.0),
+    ),
+    IMPEDANCE=ControlModeConfig(
+        entry_callback=_servo_impedance_mode_entry,
+        exit_callback=_servo_impedance_mode_exit,
+        has_gains=True,
+        max_gains=ControlGains(kp=0.0, ki=0.0, kd=0.0, k=100.0, b=10.0, ff=0.0),
+    ),
+    TORQUE=ControlModeConfig(
+        entry_callback=_servo_current_mode_entry,
+        exit_callback=_servo_current_mode_exit,
+        has_gains=True,
+        max_gains=ControlGains(kp=100.0, ki=1000.0, kd=0.0, k=0.0, b=0.0, ff=100.0),
+    ),
+    IDLE=ControlModeConfig(
+        entry_callback=_servo_idle_mode_entry,
+        exit_callback=_servo_idle_mode_exit,
+        has_gains=False,
+        max_gains=ControlGains(),
+    ),
+)
+
+
+# Default variables to be logged
 LOG_VARIABLES = [
-        "motor_position" , 
-        "motor_speed" , 
-        "motor_current", 
-        "motor_temperature" 
+    "motor_position",
+    "motor_speed", 
+    "motor_current",
+    "motor_temperature"
 ]
-"""
-default variables to be logged
-"""
+"""Default variables to be logged"""
 
-# possible states for the controller
-class _TMotorManState_Servo(Enum):
-    """
-    An Enum to keep track of different control states
-    """
-    DUTY_CYCLE = 0
-    CURRENT_LOOP = 1
-    CURRENT_BRAKE = 2
-    VELOCITY = 3
-    POSITION = 4
-    SET_ORIGIN=5
-    POSITION_VELOCITY=6
-    IDLE = 7
 
-# the user-facing class that manages the motor.
-class TMotorManager_servo_can():
+class TMotorServoActuator(ActuatorBase):
     """
-    The user-facing class that manages the motor. This class should be
-    used in the context of a with as block, in order to safely enter/exit
-    control of the motor.
+    Examples:
+        >>> with TMotorServoActuator(motor_type="AK80-9", motor_ID=1) as motor:
+        ...     motor.set_control_mode(CONTROL_MODES.POSITION)
+        ...     motor.set_position_gains(kp=10.0, ki=1.0, kd=0.5, ff=0.0)
+        ...     motor.set_motor_position(1.57)  # 90 degrees
+        ...     motor.update()
     """
-    def __init__(self, motor_type='AK80-9', motor_ID=1, max_mosfett_temp = 50, CSV_file=None, log_vars = LOG_VARIABLES):
+
+    def __init__(
+        self,
+        tag: str = "TMotorServoActuator",
+        motor_type: str = "AK80-9",
+        motor_ID: int = 1,
+        gear_ratio: float = 1.0,
+        frequency: int = 500,
+        offline: bool = False,
+        max_temperature: float = 80.0,
+        CSV_file: Optional[str] = None,
+        log_vars: Optional[list] = None,
+        **kwargs: Any,
+    ) -> None:
         """
-        Sets up the motor manager. Note the device will not be powered on by this method! You must
-        call __enter__, mostly commonly by using a with block, before attempting to control the motor.
+        Initialize TMotor servo actuator.
 
         Args:
-            motor_type: The type of motor being controlled, ie AK80-9.
-            motor_ID: The CAN ID of the motor.
-            max_mosfett_temp: temperature of the mosfett above which to throw an error, in Celsius
+            tag: Unique identifier for the actuator
+            motor_type: Motor model (AK80-9, AK10-9)
+            motor_ID: CAN ID for the motor
+            gear_ratio: Gear ratio between motor and output
+            frequency: Control loop frequency in Hz
+            offline: Whether to run in offline mode
+            max_temperature: Maximum operating temperature in Celsius
             CSV_file: A CSV file to output log info to. If None, no log will be recorded.
             log_vars: The variables to log as a python list. The full list of possibilities is
                 - "output_angle"
@@ -617,64 +513,109 @@ class TMotorManager_servo_can():
                 - "motor_velocity"
                 - "motor_acceleration"
                 - "motor_torque"
+            **kwargs: Additional arguments passed to ActuatorBase
         """
-        self.type = motor_type
+        # Validate motor type
+        if motor_type not in SERVO_PARAMS:
+            raise ValueError(f"Unsupported motor type: {motor_type}. "
+                           f"Supported types: {list(SERVO_PARAMS.keys())}")
+
+        super().__init__(
+            tag=tag,
+            gear_ratio=gear_ratio,
+            motor_constants=TMOTOR_SERVO_CONSTANTS,
+            frequency=frequency,
+            offline=offline,
+            **kwargs
+        )
+
+        # Motor configuration
+        self.motor_type = motor_type
         self.ID = motor_ID
+        self.max_temperature = max_temperature
+        
+        # Logging configuration
         self.csv_file_name = CSV_file
-        self.max_temp = max_mosfett_temp # max temp in deg C, can update later
-        print("Initializing device: " + self.device_info_string())
+        self.log_vars = log_vars or LOG_VARIABLES
+        self.LOG_FUNCTIONS = {
+            "motor_position": self.get_motor_angle_radians,
+            "motor_speed": self.get_motor_velocity_radians_per_second,
+            "motor_current": self.get_current_qaxis_amps,
+            "motor_temperature": self.get_temperature_celsius,
+        }
 
-        self._motor_state = servo_motor_state(0.0,0.0,0.0,0.0,0.0,0.0)
-        self._motor_state_async = servo_motor_state(0.0,0.0,0.0,0.0,0.0,0.0)
-        self._command = servo_command(0.0,0.0,0.0,0.0,0.0)
-        self._control_state = _TMotorManState_Servo.IDLE
+        # Get motor parameters
+        self._params = SERVO_PARAMS[motor_type]
+        if not isinstance(self._params, dict):
+            raise ValueError(f"Invalid motor parameters for {motor_type}")
 
-        self.radps_per_ERPM = 5.82E-04
-        # 2*(np.pi/180)/(Servo_Params[self.type]['NUM_POLE_PAIRS'])
-        self.rad_per_Eang = np.pi/Servo_Params[self.type]['NUM_POLE_PAIRS']
+        # State management
+        self._motor_state = ServoMotorState()
+        self._motor_state_async = ServoMotorState()
+        self._command = ServoCommand()
+        self._servo_mode = ServoControlMode.POSITION
 
-        self._entered = False
+        # Control gains
+        self._position_gains = ControlGains()
+        self._current_gains = ControlGains()
+        self._velocity_gains = ControlGains()
+        self._impedance_gains = ControlGains()
+
+        # Timing and state tracking
         self._start_time = time.time()
         self._last_update_time = self._start_time
-        self._last_command_time = None
+        self._last_command_time: Optional[float] = None
+        self._entered = False
         self._updated = False
         self._command_sent = False
-        
-        self.log_vars = log_vars
-        self.LOG_FUNCTIONS = {
-            "motor_position" : self.get_motor_angle_radians, 
-            "motor_speed" : self.get_motor_velocity_radians_per_second, 
-            "motor_current" : self.get_current_qaxis_amps, 
-            "motor_temperature" : self.get_temperature_celsius,
-        }
-        
-        self._canman = CAN_Manager_servo()
+
+        # Unit conversions
+        self.rad_per_degree = np.pi / 180.0
+        self.radps_per_erpm = 2 * np.pi / (60 * self._params['NUM_POLE_PAIRS'])
+        self.rad_per_eang = np.pi / self._params['NUM_POLE_PAIRS']
+
+        # Thermal management
+        self._thermal_model = ThermalModel(
+            temp_limit_windings=self.max_winding_temperature,
+            soft_border_C_windings=10.0,
+            temp_limit_case=self.max_case_temperature,
+            soft_border_C_case=10.0,
+        )
+
+        # CAN communication
+        if not self.is_offline:
+            self._canman = CANManagerServo()
         self._canman.add_motor(self)
-               
-    def __enter__(self):
-        """
-        Used to safely power the motor on and begin the log file.
-        """
-        print('Turning on control for device: ' + self.device_info_string())
+
+        LOGGER.info(f"Initialized TMotor servo actuator: {self.device_info_string()}")
+
+    @property
+    def _CONTROL_MODE_CONFIGS(self) -> CONTROL_MODE_CONFIGS:
+        """Get control mode configurations."""
+        return TMOTOR_SERVO_CONTROL_MODE_CONFIGS
+
+    def device_info_string(self) -> str:
+        """Get device information string."""
+        return f"{self.motor_type} ID: {self.ID}"
+
+    def __enter__(self) -> 'TMotorServoActuator':
+        """Used to safely power the motor on and begin the log file."""
+        LOGGER.info(f'Turning on control for device: {self.device_info_string()}')
+        
         if self.csv_file_name is not None:
-            with open(self.csv_file_name,'w') as fd:
+            with open(self.csv_file_name, 'w') as fd:
                 writer = csv.writer(fd)
-                writer.writerow(["pi_time"]+self.log_vars)
-            self.csv_file = open(self.csv_file_name,'a').__enter__()
+                writer.writerow(["pi_time"] + self.log_vars)
+            self.csv_file = open(self.csv_file_name, 'a').__enter__()
             self.csv_writer = csv.writer(self.csv_file)
-        self.power_on() #TODO: How to control this?
-        self._send_command()
-        self._entered = True
-        if not self.check_can_connection():
-            raise RuntimeError("Device not connected: " + str(self.device_info_string()))
+        
+        self.start()
         return self
 
-    def __exit__(self, etype, value, tb):
-        """
-        Used to safely power the motor off and close the log file.
-        """
-        print('Turning off control for device: ' + self.device_info_string())
-        self.power_off()#TODO: How to control this
+    def __exit__(self, etype: Any, value: Any, tb: Any) -> None:
+        """Used to safely power the motor off and close the log file."""
+        LOGGER.info(f'Turning off control for device: {self.device_info_string()}')
+        self.stop()
 
         if self.csv_file_name is not None:
             self.csv_file.__exit__(etype, value, tb)
@@ -682,546 +623,605 @@ class TMotorManager_servo_can():
         if not (etype is None):
             traceback.print_exception(etype, value, tb)
 
-    def qaxis_current_to_TMotor_current(self, iq):
-        gear_ratio = Servo_Params[self.type]['GEAR_RATIO']
-        kt_tmotor = Servo_Params[self.type]['Kt_TMotor']
-        current_factor = Servo_Params[self.type]['Current_Factor']
-        return iq * (gear_ratio * kt_tmotor) / current_factor
-
-    # this method is called by the handler every time a message is received on the bus
-    # from this motor, to store the most recent state information for later
-    def _update_state_async(self, servo_state):
-        """
-        This method is called by the handler every time a message is received on the bus
-        from this motor, to store the most recent state information for later
+    @check_actuator_connection
+    def start(self) -> None:
+        """Start the actuator and enable control."""
+        LOGGER.info(f"Starting control for {self.device_info_string()}")
         
-        Args:
-            servo_state: the servo_state object with the updated motor state
+        if not self.is_offline:
+            self._canman.power_on(self.ID)
+        self._send_command()
+            
+            # Verify connection
+        if not self.check_can_connection():
+                raise RuntimeError(f"Device not connected: {self.device_info_string()}")
+        
+        self._entered = True
+        self._is_open = True
+        self._is_streaming = True
 
-        Raises:
-            RuntimeError when device sends back an error code that is not 0 (0 meaning no error)
-        """
-        if servo_state.error != 0:
-            error_msg = Servo_Params['ERROR_CODES'][servo_state.error]
-            raise RuntimeError(
-                f'Driver board error for device: {self.device_info_string()}: {error_msg}'
-            )
+    @check_actuator_stream
+    @check_actuator_open
+    def stop(self) -> None:
+        """Stop the actuator and disable control."""
+        LOGGER.info(f"Stopping control for {self.device_info_string()}")
+        
+        if not self.is_offline:
+            self._canman.power_off(self.ID)
+        
+        self._is_open = False
+        self._is_streaming = False
 
-        now = time.time()
-        dt = now - self._last_update_time
-        self._last_update_time = now
-        self._motor_state_async.acceleration = (servo_state.velocity - self._motor_state_async.velocity)/dt
-        self._motor_state_async.set_state_obj(servo_state)
-        self._updated = True
-
-    
-    # this method is called by the user to synchronize the current state used by the controller
-    # with the most recent message received
-    def update(self):
-        """
-        This method is called by the user to synchronize the current state used by the controller/logger
-        with the most recent message received, as well as to send the current command.
-        """
-        # check that the motor is safely turned on
+    def update(self) -> None:
+        """Update motor state and send current command."""
         if not self._entered:
-            msg = f"Tried to update motor state before safely powering on for device: {self.device_info_string()}"
-            raise RuntimeError(msg)
+            raise RuntimeError(f"Motor not started: {self.device_info_string()}")
 
-        if self.get_temperature_celsius() > self.max_temp:
-            raise RuntimeError("Temperature greater than {}C for device: {}".format(self.max_temp, self.device_info_string()))
-        # check that the motor data is recent
+        # Temperature check
+        if self.case_temperature > self.max_temperature:
+            raise RuntimeError(f"Temperature {self.case_temperature}°C exceeds limit "
+                             f"{self.max_temperature}°C for {self.device_info_string()}")
+
+        # Communication timeout check
         now = time.time()
         if (self._last_command_time is not None and 
             (now - self._last_command_time) < 0.25 and 
-            ((now - self._last_update_time) > 0.1)):
-            msg = (f"State update requested but no data from motor. "
-                   f"Delay longer after zeroing, decrease frequency, or check connection. "
-                   f"{self.device_info_string()}")
-            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+            (now - self._last_update_time) > 0.1):
+            warnings.warn(f"No data from motor. Check connection: {self.device_info_string()}", 
+                         RuntimeWarning, stacklevel=2)
         else:
             self._command_sent = False
 
+        # Update state
         self._motor_state.set_state_obj(self._motor_state_async)
-        self._motor_state.position = self._motor_state.position/Servo_Params[self.type]["GEAR_RATIO"]
+        self._motor_state.position = self._motor_state.position / self._params['GEAR_RATIO']
         
-        # send current motor command
-        self._send_command()
+        # Send command
+        if not self.is_offline:
+            self._send_command()
 
-        # writing to log file
+        # Writing to log file
         if self.csv_file_name is not None:
             timestamp = self._last_update_time - self._start_time
             log_data = [self.LOG_FUNCTIONS[var]() for var in self.log_vars]
             self.csv_writer.writerow([timestamp] + log_data)
 
         self._updated = False
+
+    def _send_command(self) -> None:
+        """Send command based on current control mode and servo mode."""
+        if self.is_offline:
+            return
+
+        try:
+            if self._servo_mode == ServoControlMode.POSITION:
+                pos_deg = self._command.position / self.rad_per_degree
+                self._canman.set_position(self.ID, pos_deg)
+            elif self._servo_mode == ServoControlMode.POSITION_VELOCITY:
+                pos_deg = self._command.position / self.rad_per_degree
+                vel_erpm = self._command.velocity / self.radps_per_erpm
+                acc_erpm = self._command.acceleration / self.radps_per_erpm
+                self._canman.set_position_velocity(self.ID, pos_deg, vel_erpm, acc_erpm)
+            elif self._servo_mode == ServoControlMode.CURRENT_LOOP:
+                self._canman.set_current(self.ID, self._command.current)
+            elif self._servo_mode == ServoControlMode.CURRENT_BRAKE:
+                self._canman.set_current_brake(self.ID, self._command.current)
+            elif self._servo_mode == ServoControlMode.VELOCITY:
+                vel_erpm = self._command.velocity / self.radps_per_erpm
+                self._canman.set_velocity(self.ID, vel_erpm)
+            elif self._servo_mode == ServoControlMode.IDLE:
+                self._canman.set_duty_cycle(self.ID, 0.0)
+            else:
+                self._canman.set_duty_cycle(self.ID, 0.0)
+                
+            self._last_command_time = time.time()
+            self._command_sent = True
+            
+        except Exception as e:
+            LOGGER.error(f"Failed to send command: {e}")
+            raise
+
+    def _update_state_async(self, servo_state: ServoMotorState) -> None:
+        """Update motor state asynchronously from CAN messages."""
+        if servo_state.error != 0:
+            error_codes = SERVO_PARAMS['ERROR_CODES']
+            if isinstance(error_codes, dict):
+                error_msg = error_codes.get(servo_state.error, 'Unknown error')
+            else:
+                error_msg = 'Unknown error'
+            raise RuntimeError(f"Motor error {servo_state.error}: {error_msg} "
+                             f"for {self.device_info_string()}")
+
+        now = time.time()
+        dt = now - self._last_update_time
+        self._last_update_time = now
         
-    # sends a command to the motor depending on whats controlm mode the motor is in
-    def _send_command(self):
-        """
-        Sends a command to the motor depending on whats controlm mode the motor is in. This method
-        is called by update(), and should only be called on its own if you don't want to update the motor state info.
-        """
-        if self._control_state == _TMotorManState_Servo.DUTY_CYCLE:
-            self._canman.comm_can_set_duty(self.ID,self._command.duty)
-        elif self._control_state == _TMotorManState_Servo.CURRENT_LOOP:
-            self._canman.comm_can_set_current(self.ID,self._command.current)
-        elif self._control_state == _TMotorManState_Servo.CURRENT_BRAKE:
-            self._canman.comm_can_set_cb(self.ID,self._command.current)
-        elif self._control_state == _TMotorManState_Servo.VELOCITY:
-            self._canman.comm_can_set_rpm(self.ID, self._command.velocity)
-        elif self._control_state == _TMotorManState_Servo.POSITION:
-            self._canman.comm_can_set_pos(self.ID, self._command.position)
-        elif self._control_state == _TMotorManState_Servo.POSITION_VELOCITY:
-            self._canman.comm_can_set_pos_spd(
-                self.ID, self._command.position, self._command.velocity, self._command.acceleration
-            )
-        elif self._control_state == _TMotorManState_Servo.IDLE:
-            self._canman.comm_can_set_duty(self.ID, 0.0)
-
-        #TODO:Add other modes
-        else:
-            raise RuntimeError("UNDEFINED STATE for device " + self.device_info_string())
-
-        self._last_command_time = time.time()
-
-    # Basic Motor Utility Commands
-    def power_on(self):
-        """Powers on the motor."""
-        self._canman.power_on(self.ID)
+        # Calculate acceleration
+        if dt > 0:
+            self._motor_state_async.acceleration = (
+                servo_state.velocity - self._motor_state_async.velocity) / dt
+        
+        self._motor_state_async.set_state_obj(servo_state)
         self._updated = True
 
-    def power_off(self):
-        """Powers off the motor."""
-        self._canman.power_off(self.ID)
-
-    # zeros the position
-    def set_zero_position(self):
-        """Zeros the position"""
-        self._canman.comm_can_set_origin(self.ID,1)
-        self._last_command_time = time.time()
-
-    # getters for motor state
-    def get_temperature_celsius(self):
+    def home(
+        self,
+        homing_voltage: int = 2000,
+        homing_frequency: Optional[int] = None,
+        homing_direction: int = -1,
+        output_position_offset: float = 0.0,
+        current_threshold: int = 5000,
+        velocity_threshold: float = 0.001,
+    ) -> None:
         """
-        Returns:
-            The most recently updated motor temperature in degrees C.
+        Home the actuator by setting current position as zero.
+        
+        For servo mode, this simply sets the current position as the origin.
         """
+        if not self.is_offline:
+            self._canman.set_origin(self.ID, 1)  # Set permanent zero point
+            time.sleep(0.1)  # Allow command to process
+        
+        self._is_homed = True
+        LOGGER.info(f"Homed actuator: {self.device_info_string()}")
+
+    def check_can_connection(self) -> bool:
+        """Check CAN connection by sending test messages."""
+        if self.is_offline:
+            return True
+            
+        if not self._entered:
+            raise RuntimeError("Cannot check connection before starting motor control")
+
+        listener = can.BufferedReader()
+        self._canman.notifier.add_listener(listener)
+        
+        try:
+            # Send test messages
+            for _ in range(10):
+                self._canman.power_on(self.ID)
+                time.sleep(0.001)
+            
+            time.sleep(0.1)  # Wait for responses
+            
+            # Check for replies
+            success = True
+            for _ in range(10):
+                if listener.get_message(timeout=0.1) is None:
+                    success = False
+                    break
+                    
+            return success
+            
+        finally:
+            self._canman.notifier.remove_listener(listener)
+
+    # Additional utility methods from original implementation
+    def qaxis_current_to_TMotor_current(self, iq: float) -> float:
+        """Convert q-axis current to TMotor current."""
+        gear_ratio = self._params['GEAR_RATIO']
+        kt_tmotor = self._params['Kt_TMotor']
+        current_factor = self._params['Current_Factor']
+        return iq * (gear_ratio * kt_tmotor) / current_factor
+
+    def get_temperature_celsius(self) -> float:
+        """Get motor temperature in Celsius."""
         return self._motor_state.temperature
-    
-    def get_motor_error_code(self):
-        """
-        Returns:
-            The most recently updated motor error code.
-            Note the program should throw a runtime error before you get a chance to read
-            this value if it is ever anything besides 0.
 
-        Codes:
-            0 : 'No Error',
-            1 : 'Over voltage fault',           # FAULT_CODE_OVER_VOLTAGE
-            2 : 'Under voltage fault',          # FAULT_CODE_UNDER_VOLTAGE  
-            3 : 'DRV fault',                    # FAULT_CODE_DRV
-            4 : 'Absolute over current fault',  # FAULT_CODE_ABS_OVER_CURRENT
-            5 : 'Over temp FET fault',          # FAULT_CODE_OVER_TEMP_FET
-            6 : 'Over temp motor fault',        # FAULT_CODE_OVER_TEMP_MOTOR
-            7 : 'Gate driver over voltage fault', # FAULT_CODE_GATE_DRIVER_OVER_VOLTAGE
-            8 : 'Gate driver under voltage fault', # FAULT_CODE_GATE_DRIVER_UNDER_VOLTAGE
-            9 : 'MCU under voltage fault',      # FAULT_CODE_MCU_UNDER_VOLTAGE
-            10: 'Booting from watchdog reset fault', # FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET
-            11: 'Encoder SPI fault',            # FAULT_CODE_ENCODER_SPI
-            12: 'Encoder sincos below min amplitude fault', # FAULT_CODE_ENCODER_SINCOS_BELOW_MIN_AMPLITUDE
-            13: 'Encoder sincos above max amplitude fault', # FAULT_CODE_ENCODER_SINCOS_ABOVE_MAX_AMPLITUDE
-            14: 'Flash corruption fault',       # FAULT_CODE_FLASH_CORRUPTION
-            15: 'High offset current sensor 1 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_1
-            16: 'High offset current sensor 2 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_2
-            17: 'High offset current sensor 3 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_3
-            18: 'Unbalanced currents fault'     # FAULT_CODE_UNBALANCED_CURRENTS
-        """
+    def get_motor_error_code(self) -> int:
+        """Get motor error code."""
         return self._motor_state.error
 
-    def get_current_qaxis_amps(self):
-        """
-        Returns:
-            The most recently updated qaxis current in amps
-        """
+    def get_current_qaxis_amps(self) -> float:
+        """Get q-axis current in amps."""
         return self._motor_state.current
 
-    def get_output_angle_radians(self):
-        """
-        Returns:
-            The most recently updated output angle in radians
-        """
-        return self._motor_state.position*self.rad_per_Eang
+    def get_output_angle_radians(self) -> float:
+        """Get output angle in radians."""
+        return self._motor_state.position * self.rad_per_degree
 
-    def get_output_velocity_radians_per_second(self):
-        """
-        Returns:
-            The most recently updated output velocity in radians per second
-        """
-        return self._motor_state.velocity*self.radps_per_ERPM
+    def get_output_velocity_radians_per_second(self) -> float:
+        """Get output velocity in radians per second."""
+        return self._motor_state.velocity * self.radps_per_erpm
 
-    def get_output_acceleration_radians_per_second_squared(self):
-        """
-        Returns:
-            The most recently updated output acceleration in radians per second per second
-        """
+    def get_output_acceleration_radians_per_second_squared(self) -> float:
+        """Get output acceleration in radians per second squared."""
         return self._motor_state.acceleration
 
-    def get_output_torque_newton_meters(self):
-        """
-        Returns:
-            the most recently updated output torque in Nm
-        """
-        return self.get_current_qaxis_amps()*Servo_Params[self.type]["Kt_actual"]*Servo_Params[self.type]["GEAR_RATIO"]
+    def get_output_torque_newton_meters(self) -> float:
+        """Get output torque in Nm."""
+        return (self.get_current_qaxis_amps() * 
+                self._params["Kt_actual"] * 
+                self._params["GEAR_RATIO"])
 
-    def enter_duty_cycle_control(self):
-        """
-        Must call this to enable sending duty cycle commands.
-        """
-        self._control_state = _TMotorManState_Servo.DUTY_CYCLE
+    def get_motor_angle_radians(self) -> float:
+        """Get motor angle in radians."""
+        return (self._motor_state.position * 
+                self.rad_per_degree * 
+                self._params["GEAR_RATIO"])
 
-    def enter_current_control(self):
-        """
-        Must call this to enable sending current commands.
-        """
-        self._control_state = _TMotorManState_Servo.CURRENT_LOOP
+    def get_motor_velocity_radians_per_second(self) -> float:
+        """Get motor velocity in radians per second."""
+        return (self._motor_state.velocity * 
+                self.radps_per_erpm * 
+                self._params["GEAR_RATIO"])
 
-    def enter_current_brake_control(self):
-        """
-        Must call this to enable sending current brake commands.
-        """
-        self._control_state = _TMotorManState_Servo.CURRENT_BRAKE
+    def get_motor_acceleration_radians_per_second_squared(self) -> float:
+        """Get motor acceleration in radians per second squared."""
+        return self._motor_state.acceleration * self._params["GEAR_RATIO"]
 
-    def enter_velocity_control(self):
-        """
-        Must call this to enable sending velocity commands.
-        """
-        self._control_state = _TMotorManState_Servo.VELOCITY
+    def get_motor_torque_newton_meters(self) -> float:
+        """Get motor torque in Nm."""
+        return self.get_output_torque_newton_meters() / self._params["GEAR_RATIO"]
 
-    def enter_position_control(self):
-        """
-        Must call this to enable position commands.
-        """
-        self._control_state = _TMotorManState_Servo.POSITION
+    # Control mode entry methods
+    def enter_duty_cycle_control(self) -> None:
+        """Enter duty cycle control mode."""
+        self._servo_mode = ServoControlMode.DUTY_CYCLE
 
-    def enter_position_velocity_control(self):
-        """
-        Must call this to enable sending position commands with specified velocity and accleration limits.
-        """
-        self._control_state = _TMotorManState_Servo.POSITION_VELOCITY
+    def enter_current_control(self) -> None:
+        """Enter current control mode."""
+        self._servo_mode = ServoControlMode.CURRENT_LOOP
 
-    def enter_idle_mode(self):
-        """
-        Enter the idle state, where duty cycle is set to 0. (This is the default state.)
-        """
-        self._control_state = _TMotorManState_Servo.IDLE
+    def enter_current_brake_control(self) -> None:
+        """Enter current brake control mode."""
+        self._servo_mode = ServoControlMode.CURRENT_BRAKE
 
-    # used for either impedance or MIT mode to set output angle
-    def set_output_angle_radians(self, pos, vel, acc):
-        """
-        Update the current command to the desired position, when in position or position-velocity mode.
-        Note, this does not send a command, it updates the TMotorManager's saved command,
-        which will be sent when update() is called.
+    def enter_velocity_control(self) -> None:
+        """Enter velocity control mode."""
+        self._servo_mode = ServoControlMode.VELOCITY
 
-        Args:
-            pos: The desired output angle in rad
-            vel: The desired speed to get there in rad/s (when in POSITION_VELOCITY mode)
-            acc: The desired acceleration to get there in rad/s/s, ish (when in POSITION_VELOCITY mode)
-        """
-        # Convert to degrees for range checking (protocol doc specifies range in degrees)
+    def enter_position_control(self) -> None:
+        """Enter position control mode."""
+        self._servo_mode = ServoControlMode.POSITION
+
+    def enter_position_velocity_control(self) -> None:
+        """Enter position velocity control mode."""
+        self._servo_mode = ServoControlMode.POSITION_VELOCITY
+
+    def enter_idle_mode(self) -> None:
+        """Enter idle mode."""
+        self._servo_mode = ServoControlMode.IDLE
+
+    # Command setting methods
+    def set_output_angle_radians(self, pos: float, vel: float = 0.0, acc: float = 0.0) -> None:
+        """Set output angle in radians with optional velocity and acceleration."""
+        # Convert to degrees for range checking
         pos_degrees = pos * 180.0 / np.pi
-        if np.abs(pos_degrees) >= 36000:  # Based on protocol doc: -36000° to 36000°
+        p_max_deg = self._params['P_max'] * 0.1  # Convert from protocol units to degrees
+        if abs(pos_degrees) >= p_max_deg:
             raise RuntimeError(
-                f"Cannot control position with magnitude greater than {36000} degrees (630 radians)!"
+                f"Cannot control position with magnitude greater than {p_max_deg} degrees!"
             )
         
-        pos = (pos / self.rad_per_Eang)
-        vel = (vel / self.radps_per_ERPM)
-        acc = (acc / self.radps_per_ERPM)
-        if self._control_state == _TMotorManState_Servo.POSITION_VELOCITY:
+        pos = (pos / self.rad_per_degree)  # Convert to degrees for protocol
+        vel = (vel / self.radps_per_erpm)
+        acc = (acc / self.radps_per_erpm)
+        
+        if self._servo_mode == ServoControlMode.POSITION_VELOCITY:
             self._command.position = pos
             self._command.velocity = vel
             self._command.acceleration = acc
-        elif self._control_state == _TMotorManState_Servo.POSITION:
+        elif self._servo_mode == ServoControlMode.POSITION:
             self._command.position = pos
         else:
             raise RuntimeError(
                 f"Attempted to send position command without entering position control {self.device_info_string()}"
             )
 
-    def set_duty_cycle_percent(self, duty):
-        """
-        Used for duty cycle mode, to set desired duty cycle.
-        Note, this does not send a command, it updates the TMotorManager's saved command,
-        which will be sent when update() is called.
-
-        Args:
-            duty: The desired duty cycle, (-1 to 1)
-        """
-        if self._control_state not in [_TMotorManState_Servo.DUTY_CYCLE]:
+    def set_duty_cycle_percent(self, duty: float) -> None:
+        """Set duty cycle (-1 to 1)."""
+        if self._servo_mode != ServoControlMode.DUTY_CYCLE:
             raise RuntimeError(
-                f"Attempted to send duty cycle command without gains for device {self.device_info_string()}"
-            ) 
-        else:
-            if np.abs(duty) > 1:
-                raise RuntimeError("Cannot control using duty cycle mode for duty cycles greater than 100%!")
-            self._command.duty = duty
+                f"Attempted to send duty cycle command without entering duty cycle mode for device {self.device_info_string()}"
+            )
+        
+        if abs(duty) > 1:
+            raise RuntimeError("Cannot control using duty cycle mode for duty cycles greater than 100%!")
+        self._command.duty = duty
 
-    def set_output_velocity_radians_per_second(self, vel):
-        """
-        Used for velocity mode to set output velocity command.
-        Note, this does not send a command, it updates the TMotorManager's saved command,
-        which will be sent when update() is called.
-
-        Args:
-            vel: The desired output speed in rad/s
-        """
-        if np.abs(vel) >= Servo_Params[self.type]["V_max"]:
-            v_max = Servo_Params[self.type]["V_max"]
+    def set_output_velocity_radians_per_second(self, vel: float) -> None:
+        """Set output velocity in radians per second."""
+        # Convert to ERPM for range checking
+        vel_erpm = vel / self.radps_per_erpm
+        v_max = self._params["V_max"]
+        if abs(vel_erpm) >= v_max:
             raise RuntimeError(
-                f"Cannot control using speed mode for velocities with magnitude greater than {v_max}rad/s!"
+                f"Cannot control using speed mode for velocities with magnitude greater than {v_max} ERPM!"
             )
 
-        if self._control_state not in [_TMotorManState_Servo.VELOCITY]:
-            raise RuntimeError("Attempted to send speed command without gains for device " + self.device_info_string()) 
-        self._command.velocity = vel/self.radps_per_ERPM
-
-    # used for either current MIT mode to set current
-    def set_motor_current_qaxis_amps(self, current):
-        """
-        Used for current mode to set current command.
-        Note, this does not send a command, it updates the TMotorManager's saved command,
-        which will be sent when update() is called.
+        if self._servo_mode != ServoControlMode.VELOCITY:
+            raise RuntimeError("Attempted to send speed command without entering velocity mode for device " + self.device_info_string())
         
-        Args:
-            current: the desired current in amps.
-        """
-        if self._control_state not in [_TMotorManState_Servo.CURRENT_LOOP, _TMotorManState_Servo.CURRENT_BRAKE]:
+        self._command.velocity = vel_erpm
+
+    def set_motor_current_qaxis_amps(self, current: float) -> None:
+        """Set motor current in amps."""
+        if self._servo_mode not in [ServoControlMode.CURRENT_LOOP, ServoControlMode.CURRENT_BRAKE]:
             raise RuntimeError(
                 f"Attempted to send current command before entering current mode for device {self.device_info_string()}"
-            ) 
+            )
         
-        # Check current limits based on control mode
-        if self._control_state == _TMotorManState_Servo.CURRENT_BRAKE:
-            # Current brake mode: 0-60A only (based on protocol doc)
-            if current < 0 or current > 60:
-                raise RuntimeError(f"Current brake mode requires current between 0-60A, got {current}A")
+        # Check current limits based on control mode and motor parameters
+        curr_min = self._params['Curr_min'] / 1000.0  # Convert from protocol units to amps
+        curr_max = self._params['Curr_max'] / 1000.0  # Convert from protocol units to amps
+        
+        if self._servo_mode == ServoControlMode.CURRENT_BRAKE:
+            # Current brake mode: 0 to max current only
+            if current < 0 or current > curr_max:
+                raise RuntimeError(f"Current brake mode requires current between 0-{curr_max}A, got {current}A")
         else:
-            # Current loop mode: -60A to 60A
-            if current < -60 or current > 60:
-                raise RuntimeError(f"Current loop mode requires current between -60A to 60A, got {current}A")
+            # Current loop mode: min to max current
+            if current < curr_min or current > curr_max:
+                raise RuntimeError(f"Current loop mode requires current between {curr_min}A to {curr_max}A, got {current}A")
         
         self._command.current = current
 
-    # used for either current or MIT Mode to set current, based on desired torque
-    def set_output_torque_newton_meters(self, torque):
-        """
-        Used for current mode to set current, based on desired torque.
-        If a more complicated torque model is available for the motor, that will be used.
-        Otherwise it will just use the motor's torque constant.
-        
-        Args:
-            torque: The desired output torque in Nm.
-        """
-        kt_actual = Servo_Params[self.type]["Kt_actual"]
-        gear_ratio = Servo_Params[self.type]["GEAR_RATIO"]
+    def set_output_torque_newton_meters(self, torque: float) -> None:
+        """Set output torque in Nm."""
+        kt_actual = self._params["Kt_actual"]
+        gear_ratio = self._params["GEAR_RATIO"]
         self.set_motor_current_qaxis_amps(torque / kt_actual / gear_ratio)
 
-    # motor-side functions to account for the gear ratio
-    def set_motor_torque_newton_meters(self, torque):
-        """
-        Wrapper of set_output_torque that accounts for gear ratio to control motor-side torque
-        
-        Args:
-            torque: The desired motor-side torque in Nm.
-        """
-        self.set_output_torque_newton_meters(torque*Servo_Params[self.type]["GEAR_RATIO"])
+    def set_motor_torque_newton_meters(self, torque: float) -> None:
+        """Set motor torque in Nm."""
+        self.set_output_torque_newton_meters(torque * self._params["GEAR_RATIO"])
 
-    def set_motor_angle_radians(self, pos, vel=0.0, acc=0.0):
-        """
-        Wrapper for set_output_angle that accounts for gear ratio to control motor-side angle
-        
-        Args:
-            pos: The desired motor-side position in rad.
-            vel: The desired velocity in rad/s (default 0.0 for position-only mode)
-            acc: The desired acceleration in rad/s/s (default 0.0 for position-only mode)
-        """
-        self.set_output_angle_radians(pos/(Servo_Params[self.type]["GEAR_RATIO"]), vel, acc)
+    def set_motor_angle_radians(self, pos: float, vel: float = 0.0, acc: float = 0.0) -> None:
+        """Set motor angle in radians."""
+        self.set_output_angle_radians(pos / self._params["GEAR_RATIO"], vel, acc)
 
-    def set_motor_velocity_radians_per_second(self, vel):
-        """
-        Wrapper for set_output_velocity that accounts for gear ratio to control motor-side velocity
-        
-        Args:
-            vel: The desired motor-side velocity in rad/s.
-        """
-        self.set_output_velocity_radians_per_second(vel/(Servo_Params[self.type]["GEAR_RATIO"]) )
+    def set_motor_velocity_radians_per_second(self, vel: float) -> None:
+        """Set motor velocity in radians per second."""
+        self.set_output_velocity_radians_per_second(vel / self._params["GEAR_RATIO"])
 
-    def get_motor_angle_radians(self):
-        """
-        Wrapper for get_output_angle that accounts for gear ratio to get motor-side angle
-        
-        Returns:
-            The most recently updated motor-side angle in rad.
-        """
-        return self._motor_state.position*self.rad_per_Eang*Servo_Params[self.type]["GEAR_RATIO"]
+    # OSL Interface Implementation
+    def set_motor_voltage(self, value: float) -> None:
+        """Set motor voltage (not directly supported in servo mode)."""
+        # Convert voltage to approximate duty cycle
+        nominal_voltage = 24.0  # Assume 24V nominal
+        duty_cycle = np.clip(value / nominal_voltage, -1.0, 1.0)
+        self._command.duty = duty_cycle
+        self._servo_mode = ServoControlMode.DUTY_CYCLE
 
-    def get_motor_velocity_radians_per_second(self):
-        """
-        Wrapper for get_output_velocity that accounts for gear ratio to get motor-side velocity
-        
-        Returns:
-            The most recently updated motor-side velocity in rad/s.
-        """
-        return self._motor_state.velocity*self.radps_per_ERPM*Servo_Params[self.type]["GEAR_RATIO"]
+    def set_motor_current(self, value: float) -> None:
+        """Set motor current command."""
+        curr_max = self._params['Curr_max'] / 1000.0  # Convert from protocol units to amps
+        if abs(value) > curr_max:
+            raise ValueError(f"Current {value}A exceeds motor limits (±{curr_max}A)")
+        self.set_motor_current_qaxis_amps(value)
 
-    def get_motor_acceleration_radians_per_second_squared(self):
-        """
-        Wrapper for get_output_acceleration that accounts for gear ratio to get motor-side acceleration
-        
-        Returns:
-            The most recently updated motor-side acceleration in rad/s/s.
-        """
-        return self._motor_state.acceleration*Servo_Params[self.type]["GEAR_RATIO"]
+    def set_motor_position(self, value: float) -> None:
+        """Set motor position command in radians."""
+        # Convert to degrees for range checking
+        value_deg = value * 180.0 / np.pi
+        p_max_deg = self._params['P_max'] * 0.1  # Convert from protocol units to degrees
+        if abs(value_deg) >= p_max_deg:
+            raise ValueError(f"Position {value_deg}° exceeds motor limits (±{p_max_deg}°)")
+        self._command.position = value_deg  # Store in degrees
 
-    def get_motor_torque_newton_meters(self):
-        """
-        Wrapper for get_output_torque that accounts for gear ratio to get motor-side torque
-        
-        Returns:
-            The most recently updated motor-side torque in Nm.
-        """
-        return self.get_output_torque_newton_meters()/Servo_Params[self.type]["GEAR_RATIO"]
+    def set_output_position(self, value: float) -> None:
+        """Set output position command in radians."""
+        self.set_motor_position(value * self.gear_ratio)
 
-    # Simple setter methods for property compatibility
-    def set_output_angle_simple(self, pos):
-        """Simple setter for position property (only position, vel=0, acc=0)"""
-        self.set_output_angle_radians(pos, 0.0, 0.0)
+    def set_motor_torque(self, value: float) -> None:
+        """Set motor torque command in Nm."""
+        current = value / self._params['Kt_actual']
+        self.set_motor_current(current)
 
-    def set_motor_angle_simple(self, pos):
-        """Simple setter for motor angle property"""
-        self.set_motor_angle_radians(pos)
+    def set_output_torque(self, value: float) -> None:
+        """Set output torque command in Nm."""
+        motor_torque = value * self.gear_ratio
+        self.set_motor_torque(motor_torque)
 
-    # Pretty stuff
-    def __str__(self):
-        """Prints the motor's device info and current"""
-        return (
-            f"{self.device_info_string()} | Position: {self.position:.3f} rad | "
-            f"Velocity: {self.velocity:.3f} rad/s | current: {self.current_qaxis:.3f} A | "
-            f"temp: {self.temperature:.0f} C"
-        )
+    def set_current_gains(self, kp: float, ki: float, kd: float, ff: float) -> None:
+        """Set current control gains (stored for reference)."""
+        self._current_gains = ControlGains(kp=kp, ki=ki, kd=kd, ff=ff)
 
-    def device_info_string(self):
-        """Prints the motor's ID and device type."""
-        return str(self.type) + "  ID: " + str(self.ID)
+    def set_position_gains(self, kp: float, ki: float, kd: float, ff: float) -> None:
+        """Set position control gains (stored for reference)."""
+        self._position_gains = ControlGains(kp=kp, ki=ki, kd=kd, ff=ff)
 
-    # Checks the motor connection by sending a 10 commands and making sure the motor responds.
-    def check_can_connection(self):
-        """
-        Checks the motor's connection by attempting to send 10 startup messages.
-        If it gets 10 replies, then the connection is confirmed.
+    def set_impedance_gains(self, kp: float, ki: float, kd: float, 
+                          k: float, b: float, ff: float) -> None:
+        """Set impedance control gains."""
+        self._impedance_gains = ControlGains(kp=kp, ki=ki, kd=kd, k=k, b=b, ff=ff)
+        # For impedance control, use position-velocity mode with gains
+        self._servo_mode = ServoControlMode.POSITION_VELOCITY
 
-        Returns:
-            True if a connection is established and False otherwise.
-        """
-        if not self._entered:
-            msg = ("Tried to check_can_connection before entering motor control! "
-                   "Enter control using the __enter__ method, or instantiating the "
-                   "TMotorManager in a with block.")
-            raise RuntimeError(msg)
-        Listener = can.BufferedReader()
-        self._canman.notifier.add_listener(Listener)
-        for i in range(10):
-            self.power_on()
-            time.sleep(0.001)
-        success = True
-        time.sleep(0.1)  # Allow time for responses
-        for i in range(10):
-            if Listener.get_message(timeout=0.1) is None:  # Check for replies
-                success = False
-        self._canman.notifier.remove_listener(Listener)  # Remove listener to prevent memory leaks
-        return success
+    def set_velocity_gains(self, kd: float) -> None:
+        """Set velocity control gains."""
+        self._velocity_gains = ControlGains(kd=kd)
 
-    # Properties
-    temperature = property(get_temperature_celsius, doc="temperature_degrees_C")
-    """Temperature in Degrees Celsius"""
+    def set_output_velocity(self, value: float) -> None:
+        """Set output velocity command in rad/s."""
+        motor_velocity = value * self.gear_ratio
+        self.set_motor_velocity(motor_velocity)
 
-    error = property(get_motor_error_code, doc="motor_error_code")
-    """Motor error code. 0 means no error.
+    def set_motor_velocity(self, value: float) -> None:
+        """Set motor velocity command in rad/s."""
+        # Convert to ERPM for range checking
+        value_erpm = value / self.radps_per_erpm
+        v_max = self._params["V_max"]
+        if abs(value_erpm) >= v_max:
+            raise ValueError(f"Velocity {value_erpm} ERPM exceeds motor limits (±{v_max} ERPM)")
+        self._command.velocity = value_erpm
+
+    # Property implementations
+    @property
+    def motor_position(self) -> float:
+        """Get motor position in radians."""
+        return self._motor_state.position * self.rad_per_degree
+
+    @property
+    def output_position(self) -> float:
+        """Get output position in radians."""
+        return self.motor_position / self.gear_ratio
+
+    @property
+    def motor_velocity(self) -> float:
+        """Get motor velocity in rad/s."""
+        return self._motor_state.velocity * self.radps_per_erpm
+
+    @property
+    def output_velocity(self) -> float:
+        """Get output velocity in rad/s."""
+        return self.motor_velocity / self.gear_ratio
+
+    @property
+    def motor_voltage(self) -> float:
+        """Get motor voltage (estimated from duty cycle)."""
+        nominal_voltage = 24.0
+        return self._command.duty * nominal_voltage
+
+    @property
+    def motor_current(self) -> float:
+        """Get motor current in amps."""
+        return self._motor_state.current
+
+    @property
+    def motor_torque(self) -> float:
+        """Get motor torque in Nm."""
+        return self.motor_current * self._params['Kt_actual']
+
+    @property
+    def output_torque(self) -> float:
+        """Get output torque in Nm."""
+        return self.motor_torque / self.gear_ratio
+
+    @property
+    def case_temperature(self) -> float:
+        """Get case temperature in Celsius."""
+        return self._motor_state.temperature
+
+    @property
+    def winding_temperature(self) -> float:
+        """Get estimated winding temperature in Celsius."""
+        return getattr(self._thermal_model, 'T_w', self.case_temperature)
+
+    @property
+    def motor_acceleration(self) -> float:
+        """Get motor acceleration in rad/s²."""
+        return self._motor_state.acceleration * self.radps_per_erpm
+
+    @property
+    def output_acceleration(self) -> float:
+        """Get output acceleration in rad/s²."""
+        return self.motor_acceleration / self.gear_ratio
+
+    # Additional properties for compatibility
+    @property
+    def temperature(self) -> float:
+        """Temperature in degrees Celsius."""
+        return self.get_temperature_celsius()
+
+    @property
+    def error(self) -> int:
+        """Motor error code. 0 means no error."""
+        return self.get_motor_error_code()
+
+    @property
+    def current_qaxis(self) -> float:
+        """Q-axis current in amps."""
+        return self.get_current_qaxis_amps()
+
+    @property
+    def position(self) -> float:
+        """Output angle in rad."""
+        return self.get_output_angle_radians()
+
+    @property
+    def velocity(self) -> float:
+        """Output velocity in rad/s."""
+        return self.get_output_velocity_radians_per_second()
+
+    @property
+    def acceleration(self) -> float:
+        """Output acceleration in rad/s/s."""
+        return self.get_output_acceleration_radians_per_second_squared()
+
+    @property
+    def torque(self) -> float:
+        """Output torque in Nm."""
+        return self.get_output_torque_newton_meters()
+
+    @property
+    def angle_motorside(self) -> float:
+        """Motor-side angle in rad."""
+        return self.get_motor_angle_radians()
+
+    @property
+    def velocity_motorside(self) -> float:
+        """Motor-side velocity in rad/s."""
+        return self.get_motor_velocity_radians_per_second()
+
+    @property
+    def acceleration_motorside(self) -> float:
+        """Motor-side acceleration in rad/s/s."""
+        return self.get_motor_acceleration_radians_per_second_squared()
+
+    @property
+    def torque_motorside(self) -> float:
+        """Motor-side torque in Nm."""
+        return self.get_motor_torque_newton_meters()
+
+    def __str__(self) -> str:
+        """String representation of the actuator state."""
+        return (f"{self.device_info_string()} | "
+                f"Pos: {self.output_position:.3f} rad | "
+                f"Vel: {self.output_velocity:.3f} rad/s | "
+                f"Cur: {self.motor_current:.3f} A | "
+                f"Torque: {self.output_torque:.3f} Nm | "
+                f"Temp: {self.case_temperature:.1f}°C")
+
+
+if __name__ == "__main__":
+    # Current Loop Control Example
+    # Focus: Send torque commands and read motor parameters
     
-    Codes:
-        0 : 'No Error',
-        1 : 'Over voltage fault',           # FAULT_CODE_OVER_VOLTAGE
-        2 : 'Under voltage fault',          # FAULT_CODE_UNDER_VOLTAGE  
-        3 : 'DRV fault',                    # FAULT_CODE_DRV
-        4 : 'Absolute over current fault',  # FAULT_CODE_ABS_OVER_CURRENT
-        5 : 'Over temp FET fault',          # FAULT_CODE_OVER_TEMP_FET
-        6 : 'Over temp motor fault',        # FAULT_CODE_OVER_TEMP_MOTOR
-        7 : 'Gate driver over voltage fault', # FAULT_CODE_GATE_DRIVER_OVER_VOLTAGE
-        8 : 'Gate driver under voltage fault', # FAULT_CODE_GATE_DRIVER_UNDER_VOLTAGE
-        9 : 'MCU under voltage fault',      # FAULT_CODE_MCU_UNDER_VOLTAGE
-        10: 'Booting from watchdog reset fault', # FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET
-        11: 'Encoder SPI fault',            # FAULT_CODE_ENCODER_SPI
-        12: 'Encoder sincos below min amplitude fault', # FAULT_CODE_ENCODER_SINCOS_BELOW_MIN_AMPLITUDE
-        13: 'Encoder sincos above max amplitude fault', # FAULT_CODE_ENCODER_SINCOS_ABOVE_MAX_AMPLITUDE
-        14: 'Flash corruption fault',       # FAULT_CODE_FLASH_CORRUPTION
-        15: 'High offset current sensor 1 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_1
-        16: 'High offset current sensor 2 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_2
-        17: 'High offset current sensor 3 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_3
-        18: 'Unbalanced currents fault'     # FAULT_CODE_UNBALANCED_CURRENTS
-    """
-
-    # electrical variables
-    current_qaxis = property(
-        get_current_qaxis_amps, set_motor_current_qaxis_amps, doc="current_qaxis_amps_current_only"
-    )
-    """Q-axis current in amps"""
-
-    # output-side variables
-    position = property(
-        get_output_angle_radians, set_output_angle_simple, doc="output_angle_radians_impedance_only"
-    )
-    """Output angle in rad"""
-
-    velocity = property(
-        get_output_velocity_radians_per_second, 
-        set_output_velocity_radians_per_second, 
-        doc="output_velocity_radians_per_second"
-    )
-    """Output velocity in rad/s"""
-
-    acceleration = property(
-        get_output_acceleration_radians_per_second_squared, 
-        doc="output_acceleration_radians_per_second_squared"
-    )
-    """Output acceleration in rad/s/s"""
-
-    torque = property(
-        get_output_torque_newton_meters, set_output_torque_newton_meters, doc="output_torque_newton_meters"
-    )
-    """Output torque in Nm"""
-
-    # motor-side variables       
-    angle_motorside = property(
-        get_motor_angle_radians, set_motor_angle_simple, doc="motor_angle_radians_impedance_only"
-    )
-    """Motor-side angle in rad"""
+    import time
+    from opensourceleg.utilities.softrealtimeloop import SoftRealtimeLoop
+    try:
+        with TMotorServoActuator(motor_type="AK80-9", motor_ID=1, offline=True) as motor:
+            print(f"Motor: {motor.device_info_string()}")
+            
+            # Initialize
+            motor.home()
+            motor.set_control_mode(CONTROL_MODES.CURRENT)
+            print("Current loop mode activated")
+            
+            # Control loop: Send torque commands and read parameters
+            loop = SoftRealtimeLoop(dt=0.01, report=True, fade=0)
+            
+            for t in loop:
+                if t > 10.0:  # Run for 10 seconds
+                    break
+                
+                # Send torque command (example: 5Nm sine wave)
+                torque_command = 5.0 * np.sin(2 * np.pi * 0.5 * t)  # 5Nm, 0.5Hz
+                motor.set_output_torque(torque_command)
+                
+                # Update motor state
+                motor.update()
+                
+                # Read motor parameters
+                position = motor.output_position  # rad
+                velocity = motor.output_velocity  # rad/s
+                current = motor.motor_current     # A
+                temperature = motor.case_temperature  # °C
+                
+                # Display every 0.5 seconds
+                if int(t * 2) % 1 == 0:
+                    print(f"t={t:4.1f}s | Torque={torque_command:5.1f}Nm | "
+                          f"Pos={position:6.3f}rad | Vel={velocity:6.2f}rad/s | "
+                          f"Curr={current:5.1f}A | Temp={temperature:4.1f}°C")
+            
+            # Stop motor
+            motor.set_output_torque(0.0)
+            motor.update()
+            print("Motor stopped")
+            
+    except Exception as e:
+        print(f"Error: {e}")
     
-    velocity_motorside = property(
-        get_motor_velocity_radians_per_second, 
-        set_motor_velocity_radians_per_second, 
-        doc="motor_velocity_radians_per_second"
-    )
-    """Motor-side velocity in rad/s"""
-
-    acceleration_motorside = property(
-        get_motor_acceleration_radians_per_second_squared, 
-        doc="motor_acceleration_radians_per_second_squared"
-    )
-    """Motor-side acceleration in rad/s/s"""
-
-    torque_motorside = property(
-        get_motor_torque_newton_meters, set_motor_torque_newton_meters, doc="motor_torque_newton_meters"
-    )
-    """Motor-side torque in Nm"""
-
-
+    print("Example completed")

--- a/opensourceleg/actuators/tmotor
+++ b/opensourceleg/actuators/tmotor
@@ -142,7 +142,10 @@ class servo_motor_state:
         self.acceleration = other_motor_state.acceleration
 
     def __str__(self):
-        return 'Position: {} | Velocity: {} | Current: {} | Temperature: {} | Error: {}'.format(self.position, self.velocity, self.current, self.temperature, self.error)
+        return (
+            f'Position: {self.position} | Velocity: {self.velocity} | '
+            f'Current: {self.current} | Temperature: {self.temperature} | Error: {self.error}'
+        )
 
 class servo_command:
     """Data structure to store Servo command that will be sent upon update"""
@@ -228,9 +231,9 @@ class CAN_Manager_servo(object):
         
         try:
             # Configure CAN interface
-            os.system('sudo /sbin/ip link set can0 down')
-            os.system('sudo /sbin/ip link set can0 up type can bitrate 1000000')
-            os.system('sudo ifconfig can0 txqueuelen 1000')
+            os.system('sudo /sbin/ip link set can0 down')  # noqa: S605,S607
+            os.system('sudo /sbin/ip link set can0 up type can bitrate 1000000')  # noqa: S605,S607
+            os.system('sudo ifconfig can0 txqueuelen 1000')  # noqa: S605,S607
             
             # Create CAN bus object using socketcan (standard for Linux/RPi)
             self.bus = can.interface.Bus(channel='can0', bustype='socketcan')
@@ -246,14 +249,14 @@ class CAN_Manager_servo(object):
             print("1. CAN interface is available (sudo ip link show can0)")
             print("2. User has sudo privileges")
             print("3. can-utils is installed (sudo apt install can-utils)")
-            raise RuntimeError("CAN bus initialization failed")
+            raise RuntimeError("CAN bus initialization failed") from e
 
     def __del__(self):
         """
         # shut down the CAN bus when the object is deleted
         # This may not ever get called, so keep a reference and explicitly delete if this is important.
         """
-        os.system( 'sudo /sbin/ip link set can0 down' ) 
+        os.system('sudo /sbin/ip link set can0 down')  # noqa: S605,S607 
 
     # subscribe a motor object to the CAN bus to be updated upon message reception
     def add_motor(self, motor):
@@ -366,7 +369,8 @@ class CAN_Manager_servo(object):
             data: An array of integers or bytes of data to send.
         """
         DLC = data_len
-        assert (DLC <= 8), ('Data too long in message for motor ' + str(motor_id))
+        if DLC > 8:
+            raise ValueError(f'Data too long in message for motor {motor_id}')
         
         if self.debug:
             print('ID: ' + str(hex(motor_id)) + '   Data: ' + '[{}]'.format(', '.join(hex(d) for d in data)) )
@@ -420,10 +424,12 @@ class CAN_Manager_servo(object):
         """
         buffer = []
         self.buffer_append_int32(buffer, np.int32(duty * 100000.0))
-        self.send_servo_message(controller_id|(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_DUTY'] << 8), buffer, len(buffer))
+        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_DUTY'] << 8)
+        self.send_servo_message(message_id, buffer, len(buffer))
 
     # Send Servo control message for current loop mode
-    #*Current loop mode: given the Iq current specified by the motor, the motor output torque = Iq *KT, so it can be used as a torque loop
+    # *Current loop mode: given the Iq current specified by the motor, 
+    # the motor output torque = Iq *KT, so it can be used as a torque loop
     def comm_can_set_current(self, controller_id, current):
         """
         Send a servo control message for current loop mode
@@ -434,10 +440,12 @@ class CAN_Manager_servo(object):
         """
         buffer = []
         self.buffer_append_int32(buffer, np.int32(current * 1000.0))
-        self.send_servo_message(controller_id|(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_CURRENT'] << 8), buffer, len(buffer))
+        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_CURRENT'] << 8)
+        self.send_servo_message(message_id, buffer, len(buffer))
 
     # Send Servo control message for current brake mode
-    #*Current brake mode: the motor is fixed at the current position by the specified brake current given by the motor (pay attention to the motor temperature when using)
+    # *Current brake mode: the motor is fixed at the current position by the specified brake
+    # current given by the motor (pay attention to the motor temperature when using)
     def comm_can_set_cb(self, controller_id, current):
         """
         Send a servo control message for current brake mode
@@ -448,7 +456,8 @@ class CAN_Manager_servo(object):
         """
         buffer = []
         self.buffer_append_int32(buffer, np.int32(current * 1000.0))
-        self.send_servo_message(controller_id|(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_CURRENT_BRAKE'] << 8), buffer, len(buffer))
+        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_CURRENT_BRAKE'] << 8)
+        self.send_servo_message(message_id, buffer, len(buffer))
         
     # Send Servo control message for Velocity mode
     #*Velocity mode: the speed specified by the given motor
@@ -462,10 +471,12 @@ class CAN_Manager_servo(object):
         """
         buffer = []
         self.buffer_append_int32(buffer, np.int32(rpm))
-        self.send_servo_message(controller_id| (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_RPM'] << 8), buffer, len(buffer))
+        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_RPM'] << 8)
+        self.send_servo_message(message_id, buffer, len(buffer))
     
     # Send Servo control message for Position Loop mode
-    #*Position mode: Given the specified position of the motor, the motor will run to the specified position, (default speed 12000erpm acceleration 40000erpm)
+    # *Position mode: Given the specified position of the motor, the motor will run to the
+    # specified position, (default speed 12000erpm acceleration 40000erpm)
     def comm_can_set_pos(self, controller_id, pos):
         """
         Send a servo control message for position control mode
@@ -477,20 +488,26 @@ class CAN_Manager_servo(object):
         buffer = []
         # Use 10000.0 to match Arduino implementation, not 1000000.0 from protocol doc
         self.buffer_append_int32(buffer, np.int32(pos * 10000.0))
-        self.send_servo_message(controller_id|(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_POS'] << 8), buffer, len(buffer))
+        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_POS'] << 8)
+        self.send_servo_message(message_id, buffer, len(buffer))
     
     #Set origin mode
-    #*0 means setting the temporary origin (power failure elimination), 1 means setting the permanent zero point (automatic parameter saving), 2 means restoring the default zero point (automatic parameter saving)
+    # *0 means setting the temporary origin (power failure elimination), 
+    # 1 means setting the permanent zero point (automatic parameter saving), 
+    # 2 means restoring the default zero point (automatic parameter saving)
     def comm_can_set_origin(self, controller_id, set_origin_mode):
         """
         set the origin
 
         Args:
             controller_id: CAN ID of the motor to send the message to
-            set_origin_mode: 0 means setting the temporary origin (power failure elimination), 1 means setting the permanent zero point (automatic parameter saving), 2 means restoring the default zero point (automatic parameter saving)
+            set_origin_mode: 0 means setting the temporary origin (power failure elimination), 
+                1 means setting the permanent zero point (automatic parameter saving), 
+                2 means restoring the default zero point (automatic parameter saving)
         """
         buffer = [set_origin_mode]
-        self.send_servo_message(controller_id |(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_ORIGIN_HERE'] << 8), buffer, len(buffer))
+        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_ORIGIN_HERE'] << 8)
+        self.send_servo_message(message_id, buffer, len(buffer))
 
     #Position and Velocity Loop Mode
     #* Check documentation
@@ -510,7 +527,8 @@ class CAN_Manager_servo(object):
         self.buffer_append_int32(buffer, np.int32(pos * 10000.0))
         self.buffer_append_int16(buffer, np.int16(spd / 10.0))
         self.buffer_append_int16(buffer, np.int16(RPA / 10.0))
-        self.send_servo_message(controller_id |(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_POS_SPD'] << 8), buffer, len(buffer))
+        message_id = controller_id | (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_POS_SPD'] << 8)
+        self.send_servo_message(message_id, buffer, len(buffer))
 
     #* **************************END************************************************#
  
@@ -612,7 +630,8 @@ class TMotorManager_servo_can():
         self._control_state = _TMotorManState_Servo.IDLE
 
         self.radps_per_ERPM = 5.82E-04
-        self.rad_per_Eang = np.pi/Servo_Params[self.type]['NUM_POLE_PAIRS'] # 2*(np.pi/180)/(Servo_Params[self.type]['NUM_POLE_PAIRS'])
+        # 2*(np.pi/180)/(Servo_Params[self.type]['NUM_POLE_PAIRS'])
+        self.rad_per_Eang = np.pi/Servo_Params[self.type]['NUM_POLE_PAIRS']
 
         self._entered = False
         self._start_time = time.time()
@@ -664,7 +683,10 @@ class TMotorManager_servo_can():
             traceback.print_exception(etype, value, tb)
 
     def qaxis_current_to_TMotor_current(self, iq):
-        return iq*(Servo_Params[self.type]['GEAR_RATIO']*Servo_Params[self.type]['Kt_TMotor'])/Servo_Params[self.type]['Current_Factor']
+        gear_ratio = Servo_Params[self.type]['GEAR_RATIO']
+        kt_tmotor = Servo_Params[self.type]['Kt_TMotor']
+        current_factor = Servo_Params[self.type]['Current_Factor']
+        return iq * (gear_ratio * kt_tmotor) / current_factor
 
     # this method is called by the handler every time a message is received on the bus
     # from this motor, to store the most recent state information for later
@@ -680,7 +702,10 @@ class TMotorManager_servo_can():
             RuntimeError when device sends back an error code that is not 0 (0 meaning no error)
         """
         if servo_state.error != 0:
-            raise RuntimeError('Driver board error for device: ' + self.device_info_string() + ": " + Servo_Params['ERROR_CODES'][servo_state.error])
+            error_msg = Servo_Params['ERROR_CODES'][servo_state.error]
+            raise RuntimeError(
+                f'Driver board error for device: {self.device_info_string()}: {error_msg}'
+            )
 
         now = time.time()
         dt = now - self._last_update_time
@@ -699,14 +724,20 @@ class TMotorManager_servo_can():
         """
         # check that the motor is safely turned on
         if not self._entered:
-            raise RuntimeError("Tried to update motor state before safely powering on for device: " + self.device_info_string())
+            msg = f"Tried to update motor state before safely powering on for device: {self.device_info_string()}"
+            raise RuntimeError(msg)
 
         if self.get_temperature_celsius() > self.max_temp:
             raise RuntimeError("Temperature greater than {}C for device: {}".format(self.max_temp, self.device_info_string()))
         # check that the motor data is recent
         now = time.time()
-        if self._last_command_time is not None and (now - self._last_command_time) < 0.25 and ( (now - self._last_update_time) > 0.1):
-            warnings.warn("State update requested but no data from motor. Delay longer after zeroing, decrease frequency, or check connection. " + self.device_info_string(), RuntimeWarning)
+        if (self._last_command_time is not None and 
+            (now - self._last_command_time) < 0.25 and 
+            ((now - self._last_update_time) > 0.1)):
+            msg = (f"State update requested but no data from motor. "
+                   f"Delay longer after zeroing, decrease frequency, or check connection. "
+                   f"{self.device_info_string()}")
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
         else:
             self._command_sent = False
 
@@ -718,7 +749,9 @@ class TMotorManager_servo_can():
 
         # writing to log file
         if self.csv_file_name is not None:
-            self.csv_writer.writerow([self._last_update_time - self._start_time] + [self.LOG_FUNCTIONS[var]() for var in self.log_vars])
+            timestamp = self._last_update_time - self._start_time
+            log_data = [self.LOG_FUNCTIONS[var]() for var in self.log_vars]
+            self.csv_writer.writerow([timestamp] + log_data)
 
         self._updated = False
         
@@ -739,7 +772,9 @@ class TMotorManager_servo_can():
         elif self._control_state == _TMotorManState_Servo.POSITION:
             self._canman.comm_can_set_pos(self.ID, self._command.position)
         elif self._control_state == _TMotorManState_Servo.POSITION_VELOCITY:
-            self._canman.comm_can_set_pos_spd(self.ID, self._command.position, self._command.velocity, self._command.acceleration)
+            self._canman.comm_can_set_pos_spd(
+                self.ID, self._command.position, self._command.velocity, self._command.acceleration
+            )
         elif self._control_state == _TMotorManState_Servo.IDLE:
             self._canman.comm_can_set_duty(self.ID, 0.0)
 
@@ -895,7 +930,9 @@ class TMotorManager_servo_can():
         # Convert to degrees for range checking (protocol doc specifies range in degrees)
         pos_degrees = pos * 180.0 / np.pi
         if np.abs(pos_degrees) >= 36000:  # Based on protocol doc: -36000° to 36000°
-            raise RuntimeError("Cannot control position with magnitude greater than " + str(36000) + " degrees (630 radians)!")
+            raise RuntimeError(
+                f"Cannot control position with magnitude greater than {36000} degrees (630 radians)!"
+            )
         
         pos = (pos / self.rad_per_Eang)
         vel = (vel / self.radps_per_ERPM)
@@ -907,7 +944,9 @@ class TMotorManager_servo_can():
         elif self._control_state == _TMotorManState_Servo.POSITION:
             self._command.position = pos
         else:
-            raise RuntimeError("Attempted to send position command without entering position control " + self.device_info_string())
+            raise RuntimeError(
+                f"Attempted to send position command without entering position control {self.device_info_string()}"
+            )
 
     def set_duty_cycle_percent(self, duty):
         """
@@ -919,7 +958,9 @@ class TMotorManager_servo_can():
             duty: The desired duty cycle, (-1 to 1)
         """
         if self._control_state not in [_TMotorManState_Servo.DUTY_CYCLE]:
-            raise RuntimeError("Attempted to send duty cycle command without gains for device " + self.device_info_string()) 
+            raise RuntimeError(
+                f"Attempted to send duty cycle command without gains for device {self.device_info_string()}"
+            ) 
         else:
             if np.abs(duty) > 1:
                 raise RuntimeError("Cannot control using duty cycle mode for duty cycles greater than 100%!")
@@ -935,7 +976,10 @@ class TMotorManager_servo_can():
             vel: The desired output speed in rad/s
         """
         if np.abs(vel) >= Servo_Params[self.type]["V_max"]:
-            raise RuntimeError("Cannot control using speed mode for velocities with magnitude greater than " + str(Servo_Params[self.type]["V_max"]) + "rad/s!")
+            v_max = Servo_Params[self.type]["V_max"]
+            raise RuntimeError(
+                f"Cannot control using speed mode for velocities with magnitude greater than {v_max}rad/s!"
+            )
 
         if self._control_state not in [_TMotorManState_Servo.VELOCITY]:
             raise RuntimeError("Attempted to send speed command without gains for device " + self.device_info_string()) 
@@ -952,7 +996,9 @@ class TMotorManager_servo_can():
             current: the desired current in amps.
         """
         if self._control_state not in [_TMotorManState_Servo.CURRENT_LOOP, _TMotorManState_Servo.CURRENT_BRAKE]:
-            raise RuntimeError("Attempted to send current command before entering current mode for device " + self.device_info_string()) 
+            raise RuntimeError(
+                f"Attempted to send current command before entering current mode for device {self.device_info_string()}"
+            ) 
         
         # Check current limits based on control mode
         if self._control_state == _TMotorManState_Servo.CURRENT_BRAKE:
@@ -976,7 +1022,9 @@ class TMotorManager_servo_can():
         Args:
             torque: The desired output torque in Nm.
         """
-        self.set_motor_current_qaxis_amps((torque/Servo_Params[self.type]["Kt_actual"]/Servo_Params[self.type]["GEAR_RATIO"]) )
+        kt_actual = Servo_Params[self.type]["Kt_actual"]
+        gear_ratio = Servo_Params[self.type]["GEAR_RATIO"]
+        self.set_motor_current_qaxis_amps(torque / kt_actual / gear_ratio)
 
     # motor-side functions to account for the gear ratio
     def set_motor_torque_newton_meters(self, torque):
@@ -1056,7 +1104,11 @@ class TMotorManager_servo_can():
     # Pretty stuff
     def __str__(self):
         """Prints the motor's device info and current"""
-        return self.device_info_string() + " | Position: " + '{:.3f}'.format(self.position) + " rad | Velocity: " + '{:.3f}'.format(self.velocity) + " rad/s | current: " + '{:.3f}'.format(self.current_qaxis) + " A | temp: " + '{:.0f}'.format(self.temperature) + " C"
+        return (
+            f"{self.device_info_string()} | Position: {self.position:.3f} rad | "
+            f"Velocity: {self.velocity:.3f} rad/s | current: {self.current_qaxis:.3f} A | "
+            f"temp: {self.temperature:.0f} C"
+        )
 
     def device_info_string(self):
         """Prints the motor's ID and device type."""
@@ -1072,7 +1124,10 @@ class TMotorManager_servo_can():
             True if a connection is established and False otherwise.
         """
         if not self._entered:
-            raise RuntimeError("Tried to check_can_connection before entering motor control! Enter control using the __enter__ method, or instantiating the TMotorManager in a with block.")
+            msg = ("Tried to check_can_connection before entering motor control! "
+                   "Enter control using the __enter__ method, or instantiating the "
+                   "TMotorManager in a with block.")
+            raise RuntimeError(msg)
         Listener = can.BufferedReader()
         self._canman.notifier.add_listener(Listener)
         for i in range(10):
@@ -1116,36 +1171,57 @@ class TMotorManager_servo_can():
     """
 
     # electrical variables
-    current_qaxis = property(get_current_qaxis_amps, set_motor_current_qaxis_amps, doc="current_qaxis_amps_current_only")
+    current_qaxis = property(
+        get_current_qaxis_amps, set_motor_current_qaxis_amps, doc="current_qaxis_amps_current_only"
+    )
     """Q-axis current in amps"""
 
     # output-side variables
-    position = property(get_output_angle_radians, set_output_angle_simple, doc="output_angle_radians_impedance_only")
+    position = property(
+        get_output_angle_radians, set_output_angle_simple, doc="output_angle_radians_impedance_only"
+    )
     """Output angle in rad"""
 
-    velocity = property (get_output_velocity_radians_per_second, set_output_velocity_radians_per_second, doc="output_velocity_radians_per_second")
+    velocity = property(
+        get_output_velocity_radians_per_second, 
+        set_output_velocity_radians_per_second, 
+        doc="output_velocity_radians_per_second"
+    )
     """Output velocity in rad/s"""
 
-    acceleration = property(get_output_acceleration_radians_per_second_squared, doc="output_acceleration_radians_per_second_squared")
+    acceleration = property(
+        get_output_acceleration_radians_per_second_squared, 
+        doc="output_acceleration_radians_per_second_squared"
+    )
     """Output acceleration in rad/s/s"""
 
-    torque = property(get_output_torque_newton_meters, set_output_torque_newton_meters, doc="output_torque_newton_meters")
+    torque = property(
+        get_output_torque_newton_meters, set_output_torque_newton_meters, doc="output_torque_newton_meters"
+    )
     """Output torque in Nm"""
 
     # motor-side variables       
-    angle_motorside = property(get_motor_angle_radians, set_motor_angle_simple, doc="motor_angle_radians_impedance_only")
+    angle_motorside = property(
+        get_motor_angle_radians, set_motor_angle_simple, doc="motor_angle_radians_impedance_only"
+    )
     """Motor-side angle in rad"""
     
-    velocity_motorside = property (get_motor_velocity_radians_per_second, set_motor_velocity_radians_per_second, doc="motor_velocity_radians_per_second")
+    velocity_motorside = property(
+        get_motor_velocity_radians_per_second, 
+        set_motor_velocity_radians_per_second, 
+        doc="motor_velocity_radians_per_second"
+    )
     """Motor-side velocity in rad/s"""
 
-    acceleration_motorside = property(get_motor_acceleration_radians_per_second_squared, doc="motor_acceleration_radians_per_second_squared")
+    acceleration_motorside = property(
+        get_motor_acceleration_radians_per_second_squared, 
+        doc="motor_acceleration_radians_per_second_squared"
+    )
     """Motor-side acceleration in rad/s/s"""
 
-    torque_motorside = property(get_motor_torque_newton_meters, set_motor_torque_newton_meters, doc="motor_torque_newton_meters")
+    torque_motorside = property(
+        get_motor_torque_newton_meters, set_motor_torque_newton_meters, doc="motor_torque_newton_meters"
+    )
     """Motor-side torque in Nm"""
-
-
-
 
 

--- a/opensourceleg/actuators/tmotor.py
+++ b/opensourceleg/actuators/tmotor.py
@@ -1,702 +1,1148 @@
-import time
-import warnings
-from math import isfinite
-from typing import Optional
-
 import can
+import time
+import csv
+import traceback
+from enum import Enum
 import numpy as np
-from TMotorCANControl.mit_can import (
-    CAN_Manager,
-    MIT_command,
-    MIT_Params,
-    TMotorManager_mit_can,
-    motor_state,
-)
+import warnings
+import os
 
-from opensourceleg.actuators.base import (
-    CONTROL_MODE_CONFIGS,
-    CONTROL_MODES,
-    MOTOR_CONSTANTS,
-    ActuatorBase,
-    ControlModeConfig,
-)
-from opensourceleg.actuators.decorators import (
-    check_actuator_connection,
-    check_actuator_open,
-    check_actuator_stream,
-)
-from opensourceleg.math import ThermalModel
-from opensourceleg.utilities import SoftRealtimeLoop
+# Control mode contain {0,1,2,3,4,5,6,7} Seven eigenvalues correspond to seven control modes
+# respectively
+# Duty cycle mode: 0
+# Current loop mode: 1
+# Current brake mode: 2
+# Velocity mode: 3
+# Position mode: 4
+# Set origin mode:5
+# Position velocity loop mode :6
+# Parameter dictionary for each specific motor that can be controlled with this library
+# Thresholds are in the datasheet for the motor on cubemars.com
+# Verified Error codes for servo motor
 
-TMOTOR_ACTUATOR_CONSTANTS = MOTOR_CONSTANTS(
-    MOTOR_COUNT_PER_REV=16384,
-    NM_PER_AMP=0.1133,
-    NM_PER_RAD_TO_K=0.0,  # TODO: Find value
-    NM_S_PER_RAD_TO_B=0.0,  # TODO: Find value
-    MAX_CASE_TEMPERATURE=80,
-    MAX_WINDING_TEMPERATURE=110,
-)
+Servo_Params = {
+        'ERROR_CODES':{
+            0 : 'No Error',
+            1 : 'Over voltage fault',           # FAULT_CODE_OVER_VOLTAGE
+            2 : 'Under voltage fault',          # FAULT_CODE_UNDER_VOLTAGE  
+            3 : 'DRV fault',                    # FAULT_CODE_DRV
+            4 : 'Absolute over current fault',  # FAULT_CODE_ABS_OVER_CURRENT
+            5 : 'Over temp FET fault',          # FAULT_CODE_OVER_TEMP_FET
+            6 : 'Over temp motor fault',        # FAULT_CODE_OVER_TEMP_MOTOR
+            7 : 'Gate driver over voltage fault', # FAULT_CODE_GATE_DRIVER_OVER_VOLTAGE
+            8 : 'Gate driver under voltage fault', # FAULT_CODE_GATE_DRIVER_UNDER_VOLTAGE
+            9 : 'MCU under voltage fault',      # FAULT_CODE_MCU_UNDER_VOLTAGE
+            10: 'Booting from watchdog reset fault', # FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET
+            11: 'Encoder SPI fault',            # FAULT_CODE_ENCODER_SPI
+            12: 'Encoder sincos below min amplitude fault', # FAULT_CODE_ENCODER_SINCOS_BELOW_MIN_AMPLITUDE
+            13: 'Encoder sincos above max amplitude fault', # FAULT_CODE_ENCODER_SINCOS_ABOVE_MAX_AMPLITUDE
+            14: 'Flash corruption fault',       # FAULT_CODE_FLASH_CORRUPTION
+            15: 'High offset current sensor 1 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_1
+            16: 'High offset current sensor 2 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_2
+            17: 'High offset current sensor 3 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_3
+            18: 'Unbalanced currents fault'     # FAULT_CODE_UNBALANCED_CURRENTS
+        },
+        'AK10-9':{
+            'P_min' : -360000000,  # -36000 deg (based on protocol doc)
+            'P_max' : 360000000,   # 36000 deg (based on protocol doc)
+            'V_min' : -100000,     # -100000 ERPM electrical speed
+            'V_max' : 100000,      # 100000 ERPM electrical speed
+            'Curr_min': -60000,    # -60A (protocol doc: -60000-60000 represents -60A-60A)
+            'Curr_max': 60000,     # 60A (protocol doc: -60000-60000 represents -60A-60A)
+            'T_min' : -15,         # NM
+            'T_max' : 15,          # NM
+            'Temp_min': -20,       # -20°C (based on protocol doc)
+            'Temp_max': 127,       # 127°C (based on protocol doc)
+            'Kt_TMotor' : 0.16,    # from TMotor website (actually 1/Kvll)
+            'Current_Factor' : 0.59, # UNTESTED CONSTANT!
+            'Kt_actual': 0.206,    # UNTESTED CONSTANT!
+            'GEAR_RATIO': 9.0, 
+            'NUM_POLE_PAIRS': 21,
+            'Use_derived_torque_constants': False, # true if you have a better model
+        },
+        'AK80-9':{
+            'P_min' : -360000000,  # -36000 deg (based on protocol doc)
+            'P_max' : 360000000,   # 36000 deg (based on protocol doc)
+            'V_min' : -100000,     # -100000 ERPM electrical speed (same as AK10-9)
+            'V_max' : 100000,      # 100000 ERPM electrical speed (same as AK10-9)
+            'Curr_min': -60000,    # -60A (protocol doc: -60000-60000 represents -60A-60A)
+            'Curr_max': 60000,     # 60A (protocol doc: -60000-60000 represents -60A-60A)
+            'T_min' : -30,         # NM
+            'T_max' : 30,          # NM
+            'Temp_min': -20,       # -20°C (based on protocol doc)
+            'Temp_max': 127,       # 127°C (based on protocol doc)
+            'Kt_TMotor' : 0.091,   # from TMotor website (actually 1/Kvll)
+            'Current_Factor' : 0.59,
+            'Kt_actual': 0.115,
+            'GEAR_RATIO': 9.0, 
+            'NUM_POLE_PAIRS': 21,
+            'Use_derived_torque_constants': False, # true if you have a better model
+        },
+        'CAN_PACKET_ID':{
+            'CAN_PACKET_SET_DUTY':0,        # Motor runs in duty cycle mode
+            'CAN_PACKET_SET_CURRENT':1,     # Motor runs in current loop mode
+            'CAN_PACKET_SET_CURRENT_BRAKE':2, # Motor current brake mode operation
+            'CAN_PACKET_SET_RPM':3,         # Motor runs in velocity mode
+            'CAN_PACKET_SET_POS':4,         # Motor runs in position loop mode
+            'CAN_PACKET_SET_ORIGIN_HERE':5, # Set origin mode
+            'CAN_PACKET_SET_POS_SPD':6,     # Position velocity loop mode
+        },
+}
+"""
+A dictionary with the parameters needed to control the motor
+"""
+
+class servo_motor_state:
+    """Data structure to store and update motor states"""
+    def __init__(self,position, velocity, current, temperature, error, acceleration):
+        """
+        Sets the motor state to the input.
+
+        Args:
+            position: Position in rad
+            velocity: Velocity in rad/s
+            current: current in amps
+            temperature: temperature in degrees C
+            error: error code, 0 means no error
+            acceleration: acceleration in rad/s
+        """
+        self.set_state(position, velocity, current, temperature, error, acceleration)
+
+    def set_state(self, position, velocity, current, temperature, error, acceleration):
+        """
+        Sets the motor state to the input.
+
+        Args:
+            position: Position in rad
+            velocity: Velocity in rad/s
+            current: current in amps
+            temperature: temperature in degrees C
+            error: error code, 0 means no error
+            acceleration: acceleration in rad/s
+        """
+        self.position = position
+        self.velocity = velocity
+        self.current = current
+        self.temperature = temperature
+        self.error = error
+        self.acceleration = acceleration
+
+    def set_state_obj(self, other_motor_state):
+        """
+        Sets this motor state object's values to those of another motor state object.
+
+        Args:
+            other_motor_state: The other motor state object with values to set this motor state object's values to.
+        """
+        self.position = other_motor_state.position
+        self.velocity = other_motor_state.velocity
+        self.current = other_motor_state.current
+        self.temperature = other_motor_state.temperature
+        self.error = other_motor_state.error
+        self.acceleration = other_motor_state.acceleration
+
+    def __str__(self):
+        return 'Position: {} | Velocity: {} | Current: {} | Temperature: {} | Error: {}'.format(self.position, self.velocity, self.current, self.temperature, self.error)
+
+class servo_command:
+    """Data structure to store Servo command that will be sent upon update"""
+    def __init__(self, position, velocity, current, duty, acceleration):
+        """
+        Sets the motor state to the input.
+
+        Args:
+            position: Position in deg
+            velocity: Velocity in ERPM
+            current: Current in amps
+            duty: Duty cycle in percentage ratio (-1 to 1)
+            acceleration: acceleration in ERPMs
+        """
+        self.position = position
+        self.velocity = velocity
+        self.current = current
+        self.duty = duty
+        self.acceleration = acceleration
+
+# # motor state from the controller, uneditable named tuple
+# servo_motor_state = namedtuple('motor_state', 'position velocity current temperature error')
+# """
+# Motor state from the controller, uneditable named tuple
+# """
+
+# python-can listener object, with handler to be called upon reception of a message on the CAN bus
+class motorListener(can.Listener):
+    """Python-can listener object, with handler to be called upon reception of a message on the CAN bus"""
+    def __init__(self, canman, motor):
+        """
+        Sets stores can manager and motor object references
+        
+        Args:
+            canman: The CanManager object to get messages from
+            motor: The TMotorCANManager object to update
+        """
+        self.canman = canman
+        self.bus = canman.bus
+        self.motor = motor
+
+    def on_message_received(self, msg):
+        """
+        Updates this listener's motor with the info contained in msg, if that message was for this motor.
+
+        args:
+            msg: A python-can CAN message
+        """
+        data = bytes(msg.data)
+        ID = msg.arbitration_id & 0x00000FF
+        if ID == self.motor.ID:
+            self.motor._update_state_async(self.canman.parse_servo_message(data))
+
+# A class to manage the low level CAN communication protocols
+class CAN_Manager_servo(object):
+    """A class to manage the low level CAN communication protocols"""
+    debug = False
+    """
+    Set to true to display every message sent and received for debugging.
+    """
+    _instance = None
+    """
+    Used to keep track of one instantiation of the class to make a singleton object
+    """
+    
+    def __new__(cls):
+        """
+        Makes a singleton object to manage socketcan CAN bus for Raspberry Pi.
+        """
+        if not cls._instance:
+            cls._instance = super(CAN_Manager_servo, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        """
+        Initialize CAN bus connection for Raspberry Pi
+        """
+        if self._initialized:
+            return
+            
+        print("Initializing CAN Manager for Raspberry Pi")
+        
+        try:
+            # Configure CAN interface
+            os.system('sudo /sbin/ip link set can0 down')
+            os.system('sudo /sbin/ip link set can0 up type can bitrate 1000000')
+            os.system('sudo ifconfig can0 txqueuelen 1000')
+            
+            # Create CAN bus object using socketcan (standard for Linux/RPi)
+            self.bus = can.interface.Bus(channel='can0', bustype='socketcan')
+            # Create notifier for message handling
+            self.notifier = can.Notifier(bus=self.bus, listeners=[])
+            
+            print("Connected on: " + str(self.bus))
+            self._initialized = True
+            
+        except Exception as e:
+            print(f"CAN bus initialization failed: {e}")
+            print("Make sure:")
+            print("1. CAN interface is available (sudo ip link show can0)")
+            print("2. User has sudo privileges")
+            print("3. can-utils is installed (sudo apt install can-utils)")
+            raise RuntimeError("CAN bus initialization failed")
+
+    def __del__(self):
+        """
+        # shut down the CAN bus when the object is deleted
+        # This may not ever get called, so keep a reference and explicitly delete if this is important.
+        """
+        os.system( 'sudo /sbin/ip link set can0 down' ) 
+
+    # subscribe a motor object to the CAN bus to be updated upon message reception
+    def add_motor(self, motor):
+        """
+        Subscribe a motor object to the CAN bus to be updated upon message reception
+
+        Args:
+            motor: The TMotorManager object to be subscribed to the notifier
+        """
+        self.notifier.add_listener(motorListener(self, motor))
+
+#* Buffer information for servo mode data manipulation
+
+#******************START****************************#
+    # Simplified buffer functions for servo mode data manipulation
+    @staticmethod
+    def pack_int16(number):
+        """Pack 16-bit integer into byte list"""
+        return [(number >> 8) & 0xFF, number & 0xFF]
+    
+    @staticmethod
+    def pack_uint16(number):
+        """Pack unsigned 16-bit integer into byte list"""
+        return [(number >> 8) & 0xFF, number & 0xFF]
+       
+    @staticmethod
+    def pack_int32(number):
+        """Pack 32-bit integer into byte list"""
+        return [(number >> 24) & 0xFF, (number >> 16) & 0xFF, 
+                (number >> 8) & 0xFF, number & 0xFF]
+
+    @staticmethod
+    def pack_uint32(number):
+        """Pack unsigned 32-bit integer into byte list"""
+        return [(number >> 24) & 0xFF, (number >> 16) & 0xFF, 
+                (number >> 8) & 0xFF, number & 0xFF]
+
+    # Legacy methods for backward compatibility
+    @staticmethod
+    def buffer_append_int16(buffer, number, index=None):
+        """Legacy method - use pack_int16() instead"""
+        buffer.extend(CAN_Manager_servo.pack_int16(number))
+    
+    @staticmethod
+    def buffer_append_uint16(buffer, number, index=None):
+        """Legacy method - use pack_uint16() instead"""
+        buffer.extend(CAN_Manager_servo.pack_uint16(number))
+       
+    @staticmethod
+    def buffer_append_int32(buffer, number, index=None):
+        """Legacy method - use pack_int32() instead"""
+        buffer.extend(CAN_Manager_servo.pack_int32(number))
+
+    @staticmethod
+    def buffer_append_uint32(buffer, number, index=None):
+        """Legacy method - use pack_uint32() instead"""
+        buffer.extend(CAN_Manager_servo.pack_uint32(number))
+
+    # Buffer allocation for 64 bit
+    @staticmethod
+    def buffer_append_int64(buffer, number, index=None):
+        """
+        buffer size for int 64
+
+        Args:
+            Buffer: memory allocated to store data.
+            number: value.
+            index: optional index pointer (for compatibility)
+        """
+        buffer.append((number >> 56) & 0xFF)
+        buffer.append((number >> 48) & 0xFF)
+        buffer.append((number >> 40) & 0xFF)
+        buffer.append((number >> 32) & 0xFF)
+        buffer.append((number >> 24) & 0xFF)
+        buffer.append((number >> 16) & 0xFF)
+        buffer.append((number >> 8) & 0xFF)
+        buffer.append(number & 0xFF)
+
+    # Buffer allocation for Unsigned 64 bit
+    @staticmethod
+    def buffer_append_uint64(buffer, number, index=None):
+        """
+        buffer size for uint 64
+
+        Args:
+            Buffer: memory allocated to store data.
+            number: value.
+            index: optional index pointer (for compatibility)
+        """
+        buffer.append((number >> 56) & 0xFF)
+        buffer.append((number >> 48) & 0xFF)
+        buffer.append((number >> 40) & 0xFF)
+        buffer.append((number >> 32) & 0xFF)
+        buffer.append((number >> 24) & 0xFF)
+        buffer.append((number >> 16) & 0xFF)
+        buffer.append((number >> 8) & 0xFF)
+        buffer.append(number & 0xFF)
 
 
-def _tmotor_impedance_mode_exit(tmotor_actuator: "TMotorMITCANActuator") -> None:
-    tmotor_actuator.stop_motor()
+#******************END****************************#
+
+#* Sends data via CAN
+    # sends a message to the motor (when the motor is in Servo mode)
+    def send_servo_message(self, motor_id, data,data_len):
+        """
+        Sends a Servo Mode message to the motor, with a header of motor_id and data array of data
+
+        Args:
+            motor_id: The CAN ID of the motor to send to.
+            data: An array of integers or bytes of data to send.
+        """
+        DLC = data_len
+        assert (DLC <= 8), ('Data too long in message for motor ' + str(motor_id))
+        
+        if self.debug:
+            print('ID: ' + str(hex(motor_id)) + '   Data: ' + '[{}]'.format(', '.join(hex(d) for d in data)) )
+        
+        message = can.Message(arbitration_id=motor_id, data=data, is_extended_id=True)
+
+        try:
+            self.bus.send(message)
+            if self.debug:
+                print("    Message sent on " + str(self.bus.channel_info) )
+        except can.CanError as e:
+            if self.debug:
+                print("    Message NOT sent: " + e.message)
+
+    # send the power on code
+    def power_on(self, motor_id):
+        """
+        Sends the power on code to motor_id.
+
+        Args:
+            motor_id: The CAN ID of the motor to send the message to.
+            Data: This is obtained from the datasheet.
+        """
+
+        self.send_servo_message(motor_id, [ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0XFC], 8)
+        
+    # send the power off code
+    def power_off(self, motor_id):
+        """
+        Sends the power off code to motor_id.
+
+        Args:
+            motor_id: The CAN ID of the motor to send the message to.
+        """
+        self.send_servo_message(motor_id, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0XFD], 8)
 
 
-def _tmotor_current_mode_exit(tmotor_actuator: "TMotorMITCANActuator") -> None:
-    tmotor_actuator.stop_motor()
+#* Code for the working of different modes in servo mode. 
+   
+    #* ********************START*******************************************#
+    #TODO: Controller id vs motorID
+    # Send Servo control message for duty cycle mode
+    #*Duty cycle mode: duty cycle voltage is specified for a given motor, similar to squarewave drive mode
+    def comm_can_set_duty(self, controller_id, duty):
+        """
+        Send a servo control message for duty cycle mode
+
+        Args:
+            controller_id: CAN ID of the motor to send the message to
+            duty: duty cycle (-1 to 1) to use
+        """
+        buffer = []
+        self.buffer_append_int32(buffer, np.int32(duty * 100000.0))
+        self.send_servo_message(controller_id|(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_DUTY'] << 8), buffer, len(buffer))
+
+    # Send Servo control message for current loop mode
+    #*Current loop mode: given the Iq current specified by the motor, the motor output torque = Iq *KT, so it can be used as a torque loop
+    def comm_can_set_current(self, controller_id, current):
+        """
+        Send a servo control message for current loop mode
+
+        Args:
+            controller_id: CAN ID of the motor to send the message to
+            current: current in Amps to use (-60 to 60)
+        """
+        buffer = []
+        self.buffer_append_int32(buffer, np.int32(current * 1000.0))
+        self.send_servo_message(controller_id|(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_CURRENT'] << 8), buffer, len(buffer))
+
+    # Send Servo control message for current brake mode
+    #*Current brake mode: the motor is fixed at the current position by the specified brake current given by the motor (pay attention to the motor temperature when using)
+    def comm_can_set_cb(self, controller_id, current):
+        """
+        Send a servo control message for current brake mode
+
+        Args:
+            controller_id: CAN ID of the motor to send the message to
+            current: current in Amps to use (0 to 60)
+        """
+        buffer = []
+        self.buffer_append_int32(buffer, np.int32(current * 1000.0))
+        self.send_servo_message(controller_id|(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_CURRENT_BRAKE'] << 8), buffer, len(buffer))
+        
+    # Send Servo control message for Velocity mode
+    #*Velocity mode: the speed specified by the given motor
+    def comm_can_set_rpm(self, controller_id, rpm):
+        """
+        Send a servo control message for velocity control mode
+
+        Args:
+            controller_id: CAN ID of the motor to send the message to
+            rpm: velocity in ERPM (-100000 to 100000)
+        """
+        buffer = []
+        self.buffer_append_int32(buffer, np.int32(rpm))
+        self.send_servo_message(controller_id| (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_RPM'] << 8), buffer, len(buffer))
+    
+    # Send Servo control message for Position Loop mode
+    #*Position mode: Given the specified position of the motor, the motor will run to the specified position, (default speed 12000erpm acceleration 40000erpm)
+    def comm_can_set_pos(self, controller_id, pos):
+        """
+        Send a servo control message for position control mode
+
+        Args:
+            controller_id: CAN ID of the motor to send the message to
+            pos: desired position in degrees
+        """
+        buffer = []
+        # Use 10000.0 to match Arduino implementation, not 1000000.0 from protocol doc
+        self.buffer_append_int32(buffer, np.int32(pos * 10000.0))
+        self.send_servo_message(controller_id|(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_POS'] << 8), buffer, len(buffer))
+    
+    #Set origin mode
+    #*0 means setting the temporary origin (power failure elimination), 1 means setting the permanent zero point (automatic parameter saving), 2 means restoring the default zero point (automatic parameter saving)
+    def comm_can_set_origin(self, controller_id, set_origin_mode):
+        """
+        set the origin
+
+        Args:
+            controller_id: CAN ID of the motor to send the message to
+            set_origin_mode: 0 means setting the temporary origin (power failure elimination), 1 means setting the permanent zero point (automatic parameter saving), 2 means restoring the default zero point (automatic parameter saving)
+        """
+        buffer = [set_origin_mode]
+        self.send_servo_message(controller_id |(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_ORIGIN_HERE'] << 8), buffer, len(buffer))
+
+    #Position and Velocity Loop Mode
+    #* Check documentation
+    def comm_can_set_pos_spd(self, controller_id, pos, spd, RPA):
+        """
+        Send a servo control message for position control mode, with specified velocity and acceleration
+        This will be a trapezoidal speed profile.
+
+        Args:
+            controller_id: CAN ID of the motor to send the message to
+            pos: desired position in degrees
+            spd: desired max speed in ERPM
+            RPA: desired acceleration in ERPM/s
+        """
+        buffer = []
+        # Match Arduino implementation: pos * 10000.0, spd/10, RPA/10
+        self.buffer_append_int32(buffer, np.int32(pos * 10000.0))
+        self.buffer_append_int16(buffer, np.int16(spd / 10.0))
+        self.buffer_append_int16(buffer, np.int16(RPA / 10.0))
+        self.send_servo_message(controller_id |(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_POS_SPD'] << 8), buffer, len(buffer))
+
+    #* **************************END************************************************#
+ 
 
 
-def _tmotor_velocity_mode_exit(tmotor_actuator: "TMotorMITCANActuator") -> None:
-    tmotor_actuator.stop_motor()
+#*****************Parsing message data********************************#
+    def parse_servo_message(self, data):
+        """
+        Unpack the servo message into a servo_motor_state object
+
+        Args:
+            data: bytes of the message to be processed
+
+        Returns:
+            A servo_motor_state object representing the state based on the data received.
+        """
+        # using numpy to convert signed/unsigned integers
+        pos_int = np.int16(data[0] << 8 | data[1])
+        spd_int = np.int16(data[2] << 8 | data[3])
+        cur_int = np.int16(data[4] << 8 | data[5])
+        motor_pos= float( pos_int * 0.1) # motor position
+        motor_spd= float( spd_int * 10.0) # motor speed
+        motor_cur= float( cur_int * 0.01) # motor current
+        motor_temp= np.int16(data[6])  # motor temperature
+        motor_error= data[7] # motor error mode
+        if self.debug:
+            print(data)
+            print('  Position: ' + str(motor_pos))
+            print('  Velocity: ' + str(motor_spd))
+            print('  Current: ' + str(motor_cur))
+            print('  Temp: ' + str(motor_temp))
+            print('  Error: ' + str(motor_error))
+            
+        return servo_motor_state(motor_pos, motor_spd,motor_cur,motor_temp, motor_error, 0)
 
 
-TMOTOR_CONTROL_MODE_CONFIGS = CONTROL_MODE_CONFIGS(
-    IMPEDANCE=ControlModeConfig(
-        entry_callback=lambda _: None,
-        exit_callback=_tmotor_impedance_mode_exit,
-        has_gains=False,
-        max_gains=None,
-    ),
-    CURRENT=ControlModeConfig(
-        entry_callback=lambda _: None,
-        exit_callback=_tmotor_current_mode_exit,
-        has_gains=False,
-        max_gains=None,
-    ),
-    VELOCITY=ControlModeConfig(
-        entry_callback=lambda _: None,
-        exit_callback=_tmotor_velocity_mode_exit,
-        has_gains=False,
-        max_gains=None,
-    ),
-)
+# default variables to be logged
+LOG_VARIABLES = [
+        "motor_position" , 
+        "motor_speed" , 
+        "motor_current", 
+        "motor_temperature" 
+]
+"""
+default variables to be logged
+"""
 
+# possible states for the controller
+class _TMotorManState_Servo(Enum):
+    """
+    An Enum to keep track of different control states
+    """
+    DUTY_CYCLE = 0
+    CURRENT_LOOP = 1
+    CURRENT_BRAKE = 2
+    VELOCITY = 3
+    POSITION = 4
+    SET_ORIGIN=5
+    POSITION_VELOCITY=6
+    IDLE = 7
 
 # the user-facing class that manages the motor.
-class TMotorMITCANActuator(ActuatorBase, TMotorManager_mit_can):
+class TMotorManager_servo_can():
     """
     The user-facing class that manages the motor. This class should be
     used in the context of a with as block, in order to safely enter/exit
     control of the motor.
     """
-
-    def __init__(
-        self,
-        tag: str = "TMotorActuator",
-        motor_type: str = "AK80-9",
-        motor_ID: int = 41,
-        gear_ratio: float = 1.0,
-        frequency: int = 500,
-        offline: bool = False,
-        max_mosfett_temp: float = 50,
-    ):
+    def __init__(self, motor_type='AK80-9', motor_ID=1, max_mosfett_temp = 50, CSV_file=None, log_vars = LOG_VARIABLES):
         """
         Sets up the motor manager. Note the device will not be powered on by this method! You must
         call __enter__, mostly commonly by using a with block, before attempting to control the motor.
 
         Args:
-            tag: A string tag to identify the motor
-            motor_type: The type of motor to control. Must be a key in MIT_Params.
-            motor_ID: The ID of the motor to control.
-            gear_ratio: The gear ratio of the motor. Default is 1.0.
-            frequency: The frequency at which to send commands to the motor. Default is 500.
-            offline: Whether to run the motor in offline mode. Default is False.
-            max_mosfett_temp: The maximum temperature of the mosfet in degrees C. Default is 50.
+            motor_type: The type of motor being controlled, ie AK80-9.
+            motor_ID: The CAN ID of the motor.
+            max_mosfett_temp: temperature of the mosfett above which to throw an error, in Celsius
+            CSV_file: A CSV file to output log info to. If None, no log will be recorded.
+            log_vars: The variables to log as a python list. The full list of possibilities is
+                - "output_angle"
+                - "output_velocity"
+                - "output_acceleration"
+                - "current"
+                - "output_torque"
+                - "motor_angle"
+                - "motor_velocity"
+                - "motor_acceleration"
+                - "motor_torque"
         """
-        ActuatorBase.__init__(
-            self,
-            tag=tag,
-            gear_ratio=gear_ratio,
-            motor_constants=TMOTOR_ACTUATOR_CONSTANTS,
-            frequency=frequency,
-            offline=offline,
-        )
-        TMotorManager_mit_can.__init__(
-            self,
-            motor_type=motor_type,
-            motor_ID=motor_ID,
-            max_mosfett_temp=max_mosfett_temp,
-        )
         self.type = motor_type
         self.ID = motor_ID
-        # self.csv_file_name = CSV_file
+        self.csv_file_name = CSV_file
+        self.max_temp = max_mosfett_temp # max temp in deg C, can update later
         print("Initializing device: " + self.device_info_string())
 
-        self._motor_state = motor_state(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-        self._motor_state_async = motor_state(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-        self._command = MIT_command(0.0, 0.0, 0.0, 0.0, 0.0)
-        # self._control_state = _TMotorManState.IDLE
-        self._times_past_position_limit = 0
-        self._times_past_current_limit = 0
-        self._times_past_velocity_limit = 0
-        self._angle_threshold = (
-            MIT_Params[self.type]["P_max"] - 2.0
-        )  # radians, only really matters if the motor's going super fast
-        self._current_threshold = (
-            self.TMotor_current_to_qaxis_current(MIT_Params[self.type]["T_max"]) - 3.0
-        )  # A, only really matters if the current changes quick
-        self._velocity_threshold = (
-            MIT_Params[self.type]["V_max"] - 2.0
-        )  # radians, only really matters if the motor's going super fast
-        self._old_pos = None
-        self._old_curr = 0.0
-        self._old_vel = 0.0
-        self._old_current_zone = 0
-        self.max_temp = max_mosfett_temp  # max temp in deg C, can update later
+        self._motor_state = servo_motor_state(0.0,0.0,0.0,0.0,0.0,0.0)
+        self._motor_state_async = servo_motor_state(0.0,0.0,0.0,0.0,0.0,0.0)
+        self._command = servo_command(0.0,0.0,0.0,0.0,0.0)
+        self._control_state = _TMotorManState_Servo.IDLE
+
+        self.radps_per_ERPM = 5.82E-04
+        self.rad_per_Eang = np.pi/Servo_Params[self.type]['NUM_POLE_PAIRS'] # 2*(np.pi/180)/(Servo_Params[self.type]['NUM_POLE_PAIRS'])
 
         self._entered = False
         self._start_time = time.time()
         self._last_update_time = self._start_time
         self._last_command_time = None
         self._updated = False
-        self.SF = 1.0
-
-        self._thermal_model: ThermalModel = ThermalModel(
-            temp_limit_windings=self.max_winding_temperature,
-            soft_border_C_windings=10,
-            temp_limit_case=self.max_case_temperature,
-            soft_border_C_case=10,
-        )
-        self._thermal_scale: float = 1.0
-
-        self._canman = CAN_Manager()
+        self._command_sent = False
+        
+        self.log_vars = log_vars
+        self.LOG_FUNCTIONS = {
+            "motor_position" : self.get_motor_angle_radians, 
+            "motor_speed" : self.get_motor_velocity_radians_per_second, 
+            "motor_current" : self.get_current_qaxis_amps, 
+            "motor_temperature" : self.get_temperature_celsius,
+        }
+        
+        self._canman = CAN_Manager_servo()
         self._canman.add_motor(self)
-
-    @property
-    def _CONTROL_MODE_CONFIGS(self) -> CONTROL_MODE_CONFIGS:
-        return TMOTOR_CONTROL_MODE_CONFIGS
-
-    @check_actuator_connection
-    def start(self):
+               
+    def __enter__(self):
         """
-        Used to safely power the motor on and begin the log file (if specified).
+        Used to safely power the motor on and begin the log file.
         """
-        print("Turning on control for device: " + self.device_info_string())
-
-        self.power_on()
+        print('Turning on control for device: ' + self.device_info_string())
+        if self.csv_file_name is not None:
+            with open(self.csv_file_name,'w') as fd:
+                writer = csv.writer(fd)
+                writer.writerow(["pi_time"]+self.log_vars)
+            self.csv_file = open(self.csv_file_name,'a').__enter__()
+            self.csv_writer = csv.writer(self.csv_file)
+        self.power_on() #TODO: How to control this?
         self._send_command()
         self._entered = True
-        self.is_streaming = True
         if not self.check_can_connection():
             raise RuntimeError("Device not connected: " + str(self.device_info_string()))
         return self
 
-    @check_actuator_stream
-    @check_actuator_open
-    def stop(self):
+    def __exit__(self, etype, value, tb):
         """
-        Used to safely power the motor off and close the log file (if specified).
+        Used to safely power the motor off and close the log file.
         """
-        print("Turning off control for device: " + self.device_info_string())
-        self.power_off()
+        print('Turning off control for device: ' + self.device_info_string())
+        self.power_off()#TODO: How to control this
 
-    def home(
-        self,
-        homing_voltage: int = 2000,
-        homing_frequency: Optional[int] = None,
-        homing_direction: int = -1,
-        output_position_offset: float = 0.0,
-        current_threshold: int = 5000,
-        velocity_threshold: float = 0.001,
-    ):
-        pass
+        if self.csv_file_name is not None:
+            self.csv_file.__exit__(etype, value, tb)
 
-    def update(self):  # noqa: C901
-        """
-        This method is called by the user to synchronize the current state used by the controller
-        with the most recent message recieved, as well as to send the current command.
-        """
+        if not (etype is None):
+            traceback.print_exception(etype, value, tb)
 
+    def qaxis_current_to_TMotor_current(self, iq):
+        return iq*(Servo_Params[self.type]['GEAR_RATIO']*Servo_Params[self.type]['Kt_TMotor'])/Servo_Params[self.type]['Current_Factor']
+
+    # this method is called by the handler every time a message is received on the bus
+    # from this motor, to store the most recent state information for later
+    def _update_state_async(self, servo_state):
+        """
+        This method is called by the handler every time a message is received on the bus
+        from this motor, to store the most recent state information for later
+        
+        Args:
+            servo_state: the servo_state object with the updated motor state
+
+        Raises:
+            RuntimeError when device sends back an error code that is not 0 (0 meaning no error)
+        """
+        if servo_state.error != 0:
+            raise RuntimeError('Driver board error for device: ' + self.device_info_string() + ": " + Servo_Params['ERROR_CODES'][servo_state.error])
+
+        now = time.time()
+        dt = now - self._last_update_time
+        self._last_update_time = now
+        self._motor_state_async.acceleration = (servo_state.velocity - self._motor_state_async.velocity)/dt
+        self._motor_state_async.set_state_obj(servo_state)
+        self._updated = True
+
+    
+    # this method is called by the user to synchronize the current state used by the controller
+    # with the most recent message received
+    def update(self):
+        """
+        This method is called by the user to synchronize the current state used by the controller/logger
+        with the most recent message received, as well as to send the current command.
+        """
         # check that the motor is safely turned on
         if not self._entered:
-            raise RuntimeError(
-                "Tried to update motor state before safely powering on for device: " + self.device_info_string()
-            )
+            raise RuntimeError("Tried to update motor state before safely powering on for device: " + self.device_info_string())
 
-        if self.case_temperature > self.max_temp:
-            raise RuntimeError(f"Temperature greater than {self.max_temp}C for device: {self.device_info_string()}")
-
+        if self.get_temperature_celsius() > self.max_temp:
+            raise RuntimeError("Temperature greater than {}C for device: {}".format(self.max_temp, self.device_info_string()))
         # check that the motor data is recent
-        # print(self._command_sent)
         now = time.time()
-        if (now - self._last_command_time) < 0.25 and ((now - self._last_update_time) > 0.1):
-            warnings.warn(
-                "State update requested but no data from motor. Delay longer after zeroing, \
-                decrease frequency, or check connection. "
-                + self.device_info_string(),
-                RuntimeWarning,
-                stacklevel=2,
-            )
+        if self._last_command_time is not None and (now - self._last_command_time) < 0.25 and ( (now - self._last_update_time) > 0.1):
+            warnings.warn("State update requested but no data from motor. Delay longer after zeroing, decrease frequency, or check connection. " + self.device_info_string(), RuntimeWarning)
         else:
             self._command_sent = False
 
-        # artificially extending the range of the position, current, and velocity that we track
-        P_max = MIT_Params[self.type]["P_max"] + 0.01
-        I_max = self.TMotor_current_to_qaxis_current(MIT_Params[self.type]["T_max"]) + 1.0
-        V_max = MIT_Params[self.type]["V_max"] + 0.01
-
-        if self._old_pos is None:
-            self._old_pos = self._motor_state_async.position
-        old_pos = self._old_pos
-        old_curr = self._old_curr
-        old_vel = self._old_vel
-
-        new_pos = self._motor_state_async.position
-        new_curr = self._motor_state_async.current
-        new_vel = self._motor_state_async.velocity
-
-        thresh_pos = self._angle_threshold
-        thresh_curr = self._current_threshold
-        thresh_vel = self._velocity_threshold
-
-        curr_command = self._command.current
-
-        actual_current = new_curr
-
-        # The TMotor will wrap around to -max at the limits for all values it returns!! Account for this
-        if (thresh_pos <= new_pos and new_pos <= P_max) and (-P_max <= old_pos and old_pos <= -thresh_pos):
-            self._times_past_position_limit -= 1
-        elif (thresh_pos <= old_pos and old_pos <= P_max) and (-P_max <= new_pos and new_pos <= -thresh_pos):
-            self._times_past_position_limit += 1
-
-        # current is basically the same as position, but if you instantly
-        # command a switch it can actually change fast enough
-        # to throw this off, so that is accounted for too. We just put a hard limit on the current
-        # to solve current jitter problems.
-        if (thresh_curr <= new_curr and new_curr <= I_max) and (-I_max <= old_curr and old_curr <= -thresh_curr):
-            # self._old_current_zone = -1
-            # if (thresh_curr <= curr_command and curr_command <= I_max):
-            #     self._times_past_current_limit -= 1
-            if curr_command > 0:
-                actual_current = self.TMotor_current_to_qaxis_current(MIT_Params[self.type]["T_max"])
-            elif curr_command < 0:
-                actual_current = -self.TMotor_current_to_qaxis_current(MIT_Params[self.type]["T_max"])
-            else:
-                actual_current = -self.TMotor_current_to_qaxis_current(MIT_Params[self.type]["T_max"])
-            new_curr = actual_current
-        elif (thresh_curr <= old_curr and old_curr <= I_max) and (-I_max <= new_curr and new_curr <= -thresh_curr):
-            # self._old_current_zone = 1
-            # if not (-I_max <= curr_command and curr_command <= -thresh_curr):
-            #     self._times_past_current_limit += 1
-            if curr_command > 0:
-                actual_current = self.TMotor_current_to_qaxis_current(MIT_Params[self.type]["T_max"])
-            elif curr_command < 0:
-                actual_current = -self.TMotor_current_to_qaxis_current(MIT_Params[self.type]["T_max"])
-            else:
-                actual_current = self.TMotor_current_to_qaxis_current(MIT_Params[self.type]["T_max"])
-            new_curr = actual_current
-
-        # velocity should work the same as position
-        if (thresh_vel <= new_vel and new_vel <= V_max) and (-V_max <= old_vel and old_vel <= -thresh_vel):
-            self._times_past_velocity_limit -= 1
-        elif (thresh_vel <= old_vel and old_vel <= V_max) and (-V_max <= new_vel and new_vel <= -thresh_vel):
-            self._times_past_velocity_limit += 1
-
-        # update expanded state variables
-        self._old_pos = new_pos
-        self._old_curr = new_curr
-        self._old_vel = new_vel
-
         self._motor_state.set_state_obj(self._motor_state_async)
-        self._motor_state.position += self._times_past_position_limit * 2 * MIT_Params[self.type]["P_max"]
-        self._motor_state.current = actual_current
-        self._motor_state.velocity += self._times_past_velocity_limit * 2 * MIT_Params[self.type]["V_max"]
-
+        self._motor_state.position = self._motor_state.position/Servo_Params[self.type]["GEAR_RATIO"]
+        
         # send current motor command
         self._send_command()
-        self._updated = False
 
+        # writing to log file
+        if self.csv_file_name is not None:
+            self.csv_writer.writerow([self._last_update_time - self._start_time] + [self.LOG_FUNCTIONS[var]() for var in self.log_vars])
+
+        self._updated = False
+        
     # sends a command to the motor depending on whats controlm mode the motor is in
     def _send_command(self):
         """
         Sends a command to the motor depending on whats controlm mode the motor is in. This method
         is called by update(), and should only be called on its own if you don't want to update the motor state info.
-
-        Notably, the current is converted to amps from the reported 'torque' value, which is i*Kt.
-        This allows control based on actual q-axis current, rather than estimated torque, which
-        doesn't account for friction losses.
         """
-        if self.mode == CONTROL_MODES.IMPEDANCE:
-            self._canman.MIT_controller(
-                self.ID,
-                self.type,
-                self._command.position,
-                self._command.velocity,
-                self._command.kp,
-                self._command.kd,
-                0.0,
-            )
-        elif self.mode == CONTROL_MODES.CURRENT:
-            self._canman.MIT_controller(
-                self.ID,
-                self.type,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                self.qaxis_current_to_TMotor_current(self._command.current),
-            )
-        elif self.mode == CONTROL_MODES.IDLE:
-            self._canman.MIT_controller(self.ID, self.type, 0.0, 0.0, 0.0, 0.0, 0.0)
-        elif self.mode == CONTROL_MODES.VELOCITY:
-            self._canman.MIT_controller(
-                self.ID,
-                self.type,
-                0.0,
-                self._command.velocity,
-                0.0,
-                self._command.kd,
-                0.0,
-            )
+        if self._control_state == _TMotorManState_Servo.DUTY_CYCLE:
+            self._canman.comm_can_set_duty(self.ID,self._command.duty)
+        elif self._control_state == _TMotorManState_Servo.CURRENT_LOOP:
+            self._canman.comm_can_set_current(self.ID,self._command.current)
+        elif self._control_state == _TMotorManState_Servo.CURRENT_BRAKE:
+            self._canman.comm_can_set_cb(self.ID,self._command.current)
+        elif self._control_state == _TMotorManState_Servo.VELOCITY:
+            self._canman.comm_can_set_rpm(self.ID, self._command.velocity)
+        elif self._control_state == _TMotorManState_Servo.POSITION:
+            self._canman.comm_can_set_pos(self.ID, self._command.position)
+        elif self._control_state == _TMotorManState_Servo.POSITION_VELOCITY:
+            self._canman.comm_can_set_pos_spd(self.ID, self._command.position, self._command.velocity, self._command.acceleration)
+        elif self._control_state == _TMotorManState_Servo.IDLE:
+            self._canman.comm_can_set_duty(self.ID, 0.0)
+
+        #TODO:Add other modes
         else:
             raise RuntimeError("UNDEFINED STATE for device " + self.device_info_string())
+
+        self._last_command_time = time.time()
+
+    # Basic Motor Utility Commands
+    def power_on(self):
+        """Powers on the motor."""
+        self._canman.power_on(self.ID)
+        self._updated = True
+
+    def power_off(self):
+        """Powers off the motor."""
+        self._canman.power_off(self.ID)
+
+    # zeros the position
+    def set_zero_position(self):
+        """Zeros the position"""
+        self._canman.comm_can_set_origin(self.ID,1)
         self._last_command_time = time.time()
 
     # getters for motor state
-    @property
-    def case_temperature(self) -> float:
+    def get_temperature_celsius(self):
         """
         Returns:
-        The most recently updated motor temperature in degrees C.
+            The most recently updated motor temperature in degrees C.
         """
-        return float(self._motor_state.temperature)
-
-    @property
-    def winding_temperature(self) -> float:
-        """
-        ESTIMATED temperature of the windings in celsius.
-        This is calculated based on the thermal model using motor current.
-        """
-        if self._data is not None:
-            return float(self._thermal_model.T_w)
-        else:
-            return 0.0
-
-    @property
-    def motor_current(self) -> float:
+        return self._motor_state.temperature
+    
+    def get_motor_error_code(self):
         """
         Returns:
-        The most recently updated qaxis current in amps
+            The most recently updated motor error code.
+            Note the program should throw a runtime error before you get a chance to read
+            this value if it is ever anything besides 0.
+
+        Codes:
+            0 : 'No Error',
+            1 : 'Over voltage fault',           # FAULT_CODE_OVER_VOLTAGE
+            2 : 'Under voltage fault',          # FAULT_CODE_UNDER_VOLTAGE  
+            3 : 'DRV fault',                    # FAULT_CODE_DRV
+            4 : 'Absolute over current fault',  # FAULT_CODE_ABS_OVER_CURRENT
+            5 : 'Over temp FET fault',          # FAULT_CODE_OVER_TEMP_FET
+            6 : 'Over temp motor fault',        # FAULT_CODE_OVER_TEMP_MOTOR
+            7 : 'Gate driver over voltage fault', # FAULT_CODE_GATE_DRIVER_OVER_VOLTAGE
+            8 : 'Gate driver under voltage fault', # FAULT_CODE_GATE_DRIVER_UNDER_VOLTAGE
+            9 : 'MCU under voltage fault',      # FAULT_CODE_MCU_UNDER_VOLTAGE
+            10: 'Booting from watchdog reset fault', # FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET
+            11: 'Encoder SPI fault',            # FAULT_CODE_ENCODER_SPI
+            12: 'Encoder sincos below min amplitude fault', # FAULT_CODE_ENCODER_SINCOS_BELOW_MIN_AMPLITUDE
+            13: 'Encoder sincos above max amplitude fault', # FAULT_CODE_ENCODER_SINCOS_ABOVE_MAX_AMPLITUDE
+            14: 'Flash corruption fault',       # FAULT_CODE_FLASH_CORRUPTION
+            15: 'High offset current sensor 1 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_1
+            16: 'High offset current sensor 2 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_2
+            17: 'High offset current sensor 3 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_3
+            18: 'Unbalanced currents fault'     # FAULT_CODE_UNBALANCED_CURRENTS
         """
-        return float(self._motor_state.current)
+        return self._motor_state.error
 
-    @property
-    def motor_voltage(self) -> float:
-        # Not implemented
-        return 0.0
-
-    @property
-    def output_position(self) -> float:
+    def get_current_qaxis_amps(self):
         """
         Returns:
-        The most recently updated output angle in radians
+            The most recently updated qaxis current in amps
         """
-        return float(self._motor_state.position)
+        return self._motor_state.current
 
-    @property
-    def output_velocity(self) -> float:
+    def get_output_angle_radians(self):
+        """
+        Returns:
+            The most recently updated output angle in radians
+        """
+        return self._motor_state.position*self.rad_per_Eang
+
+    def get_output_velocity_radians_per_second(self):
         """
         Returns:
             The most recently updated output velocity in radians per second
         """
-        return float(self._motor_state.velocity)
+        return self._motor_state.velocity*self.radps_per_ERPM
 
-    @property
-    def output_acceleration(self) -> float:
+    def get_output_acceleration_radians_per_second_squared(self):
         """
         Returns:
             The most recently updated output acceleration in radians per second per second
         """
-        return float(self._motor_state.acceleration)
+        return self._motor_state.acceleration
 
-    @property
-    def output_torque(self) -> float:
+    def get_output_torque_newton_meters(self):
         """
         Returns:
             the most recently updated output torque in Nm
         """
-        return float(self.motor_current * MIT_Params[self.type]["Kt_actual"] * MIT_Params[self.type]["GEAR_RATIO"])
+        return self.get_current_qaxis_amps()*Servo_Params[self.type]["Kt_actual"]*Servo_Params[self.type]["GEAR_RATIO"]
 
-    # uses plain impedance mode, will send 0.0 for current command.
-    def set_impedance_gains(
-        self,
-        kp: float = 0,
-        ki: float = 0,
-        K: float = 0.08922,
-        B: float = 0.0038070,
-        ff: float = 0,
-    ) -> None:
+    def enter_duty_cycle_control(self):
         """
-        Uses plain impedance mode, will send 0.0 for current command in addition to position request.
-
-        Args:
-            kp: A dummy argument for backward compatibility with the dephy library.
-            ki: A dummy argument for backward compatibility with the dephy library.
-            K: The stiffness in Nm/rad
-            B: The damping in Nm/(rad/s)
-            ff: A dummy argument for backward compatibility with the dephy library.
+        Must call this to enable sending duty cycle commands.
         """
-        if not (isfinite(K) and MIT_Params[self.type]["Kp_min"] <= K and MIT_Params[self.type]["Kp_max"] >= K):
-            raise ValueError(
-                f"K must be finite and between \
-                {MIT_Params[self.type]['Kp_min']} and {MIT_Params[self.type]['Kp_max']}"
-            )
+        self._control_state = _TMotorManState_Servo.DUTY_CYCLE
 
-        if not (isfinite(B) and MIT_Params[self.type]["Kd_min"] <= B and MIT_Params[self.type]["Kd_max"] >= B):
-            raise ValueError(
-                f"B must be finite and between \
-                {MIT_Params[self.type]['Kd_min']} and {MIT_Params[self.type]['Kd_max']}"
-            )
-
-        self._command.kp = K
-        self._command.kd = B
-        self._command.velocity = 0.0
-
-    def set_current_gains(
-        self,
-        kp: float = 40,
-        ki: float = 400,
-        ff: float = 128,
-        spoof: bool = False,
-    ) -> None:
+    def enter_current_control(self):
         """
-        Uses plain current mode, will send 0.0 for position gains in addition to requested current.
-
-        Args:
-            kp: A dummy argument for backward compatibility with the dephy library.
-            ki: A dummy argument for backward compatibility with the dephy library.
-            ff: A dummy argument for backward compatibility with the dephy library.
-            spoof: A dummy argument for backward compatibility with the dephy library.
+        Must call this to enable sending current commands.
         """
-        pass
+        self._control_state = _TMotorManState_Servo.CURRENT_LOOP
 
-    def set_velocity_gains(
-        self,
-        kd: float = 1.0,
-    ) -> None:
+    def enter_current_brake_control(self):
         """
-        Uses plain speed mode, will send 0.0 for position gain and for feed forward current.
-
-        Args:
-            kd: The gain for the speed controller. Control law will be (v_des - v_actual)*kd = iq
+        Must call this to enable sending current brake commands.
         """
-        self._command.kd = kd
+        self._control_state = _TMotorManState_Servo.CURRENT_BRAKE
 
-    def set_position_gains(self) -> None:
-        # Not implemented
-        pass
+    def enter_velocity_control(self):
+        """
+        Must call this to enable sending velocity commands.
+        """
+        self._control_state = _TMotorManState_Servo.VELOCITY
+
+    def enter_position_control(self):
+        """
+        Must call this to enable position commands.
+        """
+        self._control_state = _TMotorManState_Servo.POSITION
+
+    def enter_position_velocity_control(self):
+        """
+        Must call this to enable sending position commands with specified velocity and accleration limits.
+        """
+        self._control_state = _TMotorManState_Servo.POSITION_VELOCITY
+
+    def enter_idle_mode(self):
+        """
+        Enter the idle state, where duty cycle is set to 0. (This is the default state.)
+        """
+        self._control_state = _TMotorManState_Servo.IDLE
 
     # used for either impedance or MIT mode to set output angle
-    def set_output_position(self, value: float) -> None:
+    def set_output_angle_radians(self, pos, vel, acc):
         """
-        Used for either impedance or full state feedback mode to set output angle command.
+        Update the current command to the desired position, when in position or position-velocity mode.
         Note, this does not send a command, it updates the TMotorManager's saved command,
         which will be sent when update() is called.
 
         Args:
-            value: The desired output position in rads
-
-        Raises:
-            RuntimeError: If the position command is outside the range of the motor.
+            pos: The desired output angle in rad
+            vel: The desired speed to get there in rad/s (when in POSITION_VELOCITY mode)
+            acc: The desired acceleration to get there in rad/s/s, ish (when in POSITION_VELOCITY mode)
         """
-        if np.abs(value) >= MIT_Params[self.type]["P_max"]:
-            raise RuntimeError(
-                "Cannot control using impedance mode for angles with magnitude greater than "
-                + str(MIT_Params[self.type]["P_max"])
-                + "rad!"
-            )
+        # Convert to degrees for range checking (protocol doc specifies range in degrees)
+        pos_degrees = pos * 180.0 / np.pi
+        if np.abs(pos_degrees) >= 36000:  # Based on protocol doc: -36000° to 36000°
+            raise RuntimeError("Cannot control position with magnitude greater than " + str(36000) + " degrees (630 radians)!")
+        
+        pos = (pos / self.rad_per_Eang)
+        vel = (vel / self.radps_per_ERPM)
+        acc = (acc / self.radps_per_ERPM)
+        if self._control_state == _TMotorManState_Servo.POSITION_VELOCITY:
+            self._command.position = pos
+            self._command.velocity = vel
+            self._command.acceleration = acc
+        elif self._control_state == _TMotorManState_Servo.POSITION:
+            self._command.position = pos
+        else:
+            raise RuntimeError("Attempted to send position command without entering position control " + self.device_info_string())
 
-        self._command.position = value
-
-    def set_output_velocity(self, value: float) -> None:
+    def set_duty_cycle_percent(self, duty):
         """
-        Used for either speed or full state feedback mode to set output velocity command.
+        Used for duty cycle mode, to set desired duty cycle.
         Note, this does not send a command, it updates the TMotorManager's saved command,
         which will be sent when update() is called.
 
         Args:
-            value: The desired output speed in rad/s
-
-        Raises:
-            RuntimeError: If the velocity command is outside the range of the motor.
+            duty: The desired duty cycle, (-1 to 1)
         """
-        if np.abs(value) >= MIT_Params[self.type]["V_max"]:
-            raise RuntimeError(
-                "Cannot control using speed mode for angles with magnitude greater than "
-                + str(MIT_Params[self.type]["V_max"])
-                + "rad/s!"
-            )
+        if self._control_state not in [_TMotorManState_Servo.DUTY_CYCLE]:
+            raise RuntimeError("Attempted to send duty cycle command without gains for device " + self.device_info_string()) 
+        else:
+            if np.abs(duty) > 1:
+                raise RuntimeError("Cannot control using duty cycle mode for duty cycles greater than 100%!")
+            self._command.duty = duty
 
-        self._command.velocity = value
+    def set_output_velocity_radians_per_second(self, vel):
+        """
+        Used for velocity mode to set output velocity command.
+        Note, this does not send a command, it updates the TMotorManager's saved command,
+        which will be sent when update() is called.
+
+        Args:
+            vel: The desired output speed in rad/s
+        """
+        if np.abs(vel) >= Servo_Params[self.type]["V_max"]:
+            raise RuntimeError("Cannot control using speed mode for angles with magnitude greater than " + str(Servo_Params[self.type]["V_max"]) + "rad/s!")
+
+        if self._control_state not in [_TMotorManState_Servo.VELOCITY]:
+            raise RuntimeError("Attempted to send speed command without gains for device " + self.device_info_string()) 
+        self._command.velocity = vel/self.radps_per_ERPM
 
     # used for either current MIT mode to set current
-
-    def set_motor_current(self, value: float) -> None:
+    def set_motor_current_qaxis_amps(self, current):
         """
-        Used for either current or full state feedback mode to set current command.
+        Used for current mode to set current command.
         Note, this does not send a command, it updates the TMotorManager's saved command,
         which will be sent when update() is called.
-
+        
         Args:
-            value: the desired current in amps.
+            current: the desired current in amps.
         """
-        self._command.current = value
+        if self._control_state not in [_TMotorManState_Servo.CURRENT_LOOP, _TMotorManState_Servo.CURRENT_BRAKE]:
+            raise RuntimeError("Attempted to send current command before entering current mode for device " + self.device_info_string()) 
+        
+        # Check current limits based on control mode
+        if self._control_state == _TMotorManState_Servo.CURRENT_BRAKE:
+            # Current brake mode: 0-60A only (based on protocol doc)
+            if current < 0 or current > 60:
+                raise RuntimeError(f"Current brake mode requires current between 0-60A, got {current}A")
+        else:
+            # Current loop mode: -60A to 60A
+            if current < -60 or current > 60:
+                raise RuntimeError(f"Current loop mode requires current between -60A to 60A, got {current}A")
+        
+        self._command.current = current
 
     # used for either current or MIT Mode to set current, based on desired torque
-    def set_output_torque(self, value: float) -> None:
+    def set_output_torque_newton_meters(self, torque):
         """
-        Used for either current or MIT Mode to set current, based on desired torque.
+        Used for current mode to set current, based on desired torque.
         If a more complicated torque model is available for the motor, that will be used.
         Otherwise it will just use the motor's torque constant.
-
+        
         Args:
-            value: The desired output torque in Nm.
+            torque: The desired output torque in Nm.
         """
-        self.set_motor_current(value / MIT_Params[self.type]["Kt_actual"] / MIT_Params[self.type]["GEAR_RATIO"])
+        self.set_motor_current_qaxis_amps((torque/Servo_Params[self.type]["Kt_actual"]/Servo_Params[self.type]["GEAR_RATIO"]) )
 
     # motor-side functions to account for the gear ratio
-    def set_motor_torque(self, value: float) -> None:
+    def set_motor_torque_newton_meters(self, torque):
         """
-        Version of set_output_torque that accounts for gear ratio to control motor-side torque
-
+        Wrapper of set_output_torque that accounts for gear ratio to control motor-side torque
+        
         Args:
-            value: The desired motor torque in Nm.
+            torque: The desired motor-side torque in Nm.
         """
-        self.set_output_torque(value * MIT_Params[self.type]["Kt_actual"])
+        self.set_output_torque_newton_meters(torque*Servo_Params[self.type]["GEAR_RATIO"])
 
-    def set_motor_position(self, value: float) -> None:
+    def set_motor_angle_radians(self, pos, vel=0.0, acc=0.0):
         """
         Wrapper for set_output_angle that accounts for gear ratio to control motor-side angle
-
+        
         Args:
-            value: The desired motor position in rad.
+            pos: The desired motor-side position in rad.
+            vel: The desired velocity in rad/s (default 0.0 for position-only mode)
+            acc: The desired acceleration in rad/s/s (default 0.0 for position-only mode)
         """
-        self.set_output_position(value / (MIT_Params[self.type]["GEAR_RATIO"]))
+        self.set_output_angle_radians(pos/(Servo_Params[self.type]["GEAR_RATIO"]), vel, acc)
 
-    def set_motor_velocity(self, value: float) -> None:
+    def set_motor_velocity_radians_per_second(self, vel):
         """
         Wrapper for set_output_velocity that accounts for gear ratio to control motor-side velocity
-
+        
         Args:
-            value: The desired motor velocity in rad/s.
+            vel: The desired motor-side velocity in rad/s.
         """
-        self.set_output_velocity(value / (MIT_Params[self.type]["GEAR_RATIO"]))
+        self.set_output_velocity_radians_per_second(vel/(Servo_Params[self.type]["GEAR_RATIO"]) )
 
-    def set_motor_voltage(self, value: float) -> float:
-        # Not implemented
-        pass
-
-    @property
-    def motor_position(self) -> float:
+    def get_motor_angle_radians(self):
         """
         Wrapper for get_output_angle that accounts for gear ratio to get motor-side angle
-
+        
         Returns:
             The most recently updated motor-side angle in rad.
         """
-        return float(self._motor_state.position * MIT_Params[self.type]["GEAR_RATIO"])
+        return self._motor_state.position*self.rad_per_Eang*Servo_Params[self.type]["GEAR_RATIO"]
 
-    @property
-    def motor_velocity(self) -> float:
+    def get_motor_velocity_radians_per_second(self):
         """
         Wrapper for get_output_velocity that accounts for gear ratio to get motor-side velocity
-
+        
         Returns:
             The most recently updated motor-side velocity in rad/s.
         """
-        return float(self._motor_state.velocity * MIT_Params[self.type]["GEAR_RATIO"])
+        return self._motor_state.velocity*self.radps_per_ERPM*Servo_Params[self.type]["GEAR_RATIO"]
 
-    @property
-    def motor_acceleration(self) -> float:
+    def get_motor_acceleration_radians_per_second_squared(self):
         """
         Wrapper for get_output_acceleration that accounts for gear ratio to get motor-side acceleration
-
+        
         Returns:
             The most recently updated motor-side acceleration in rad/s/s.
         """
-        return float(self._motor_state.acceleration * MIT_Params[self.type]["GEAR_RATIO"])
+        return self._motor_state.acceleration*Servo_Params[self.type]["GEAR_RATIO"]
 
-    @property
-    def motor_torque(self) -> float:
+    def get_motor_torque_newton_meters(self):
         """
         Wrapper for get_output_torque that accounts for gear ratio to get motor-side torque
-
+        
         Returns:
             The most recently updated motor-side torque in Nm.
         """
-        return float(self.output_torque * MIT_Params[self.type]["GEAR_RATIO"])
+        return self.get_output_torque_newton_meters()/Servo_Params[self.type]["GEAR_RATIO"]
+
+    # Simple setter methods for property compatibility
+    def set_output_angle_simple(self, pos):
+        """Simple setter for position property (only position, vel=0, acc=0)"""
+        self.set_output_angle_radians(pos, 0.0, 0.0)
+
+    def set_motor_angle_simple(self, pos):
+        """Simple setter for motor angle property"""
+        self.set_motor_angle_radians(pos)
 
     # Pretty stuff
-    def __str__(self) -> str:
+    def __str__(self):
         """Prints the motor's device info and current"""
-        return (
-            self.device_info_string()
-            + " | Position: "
-            + f"{round(self.output_angle, 3): 1f}"
-            + " rad | Velocity: "
-            + f"{round(self.output_velocity, 3): 1f}"
-            + " rad/s | current: "
-            + f"{round(self.motor_current, 3): 1f}"
-            + " A | torque: "
-            + f"{round(self.output_torque, 3): 1f}"
-            + " Nm"
-        )
+        return self.device_info_string() + " | Position: " + '{: 1f}'.format(round(self.position,3)) + " rad | Velocity: " + '{: 1f}'.format(round(self.velocity,3)) + " rad/s | current: " + '{: 1f}'.format(round(self.current_qaxis,3)) + " A | temp: " + '{: 1f}'.format(round(self.temperature,0)) + " C"
+
+    def device_info_string(self):
+        """Prints the motor's ID and device type."""
+        return str(self.type) + "  ID: " + str(self.ID)
 
     # Checks the motor connection by sending a 10 commands and making sure the motor responds.
-    def check_can_connection(self) -> bool:
+    def check_can_connection(self):
         """
         Checks the motor's connection by attempting to send 10 startup messages.
         If it gets 10 replies, then the connection is confirmed.
 
         Returns:
             True if a connection is established and False otherwise.
-
-        Raises:
-            RuntimeError: If the motor control has not been entered.
         """
         if not self._entered:
-            raise RuntimeError(
-                "Tried to check_can_connection before entering motor control! \
-                Enter control using the __enter__ method, or instantiating the TMotorManager in a with block."
-            )
+            raise RuntimeError("Tried to check_can_connection before entering motor control! Enter control using the __enter__ method, or instantiating the TMotorManager in a with block.")
         Listener = can.BufferedReader()
         self._canman.notifier.add_listener(Listener)
-        for _i in range(10):
+        for i in range(10):
             self.power_on()
             time.sleep(0.001)
         success = True
-        self._is_open = True
-        time.sleep(0.1)
-        for _i in range(10):
-            if Listener.get_message(timeout=0.1) is None:
-                success = False
-                self._is_open = False
-        self._canman.notifier.remove_listener(Listener)
+        # time.sleep(0.1)
+        # for i in range(10):
+        #     if Listener.get_message(timeout=0.1) is None:
+        #         success = False
+        # self._canman.notifier.remove_listener(Listener)
         return success
 
+    # Properties
+    temperature = property(get_temperature_celsius, doc="temperature_degrees_C")
+    """Temperature in Degrees Celsius"""
 
-if __name__ == "__main__":
-    with TMotorMITCANActuator(motor_type="AK80-9", motor_ID=41) as dev:
-        dev.set_zero_position()  # has a delay!
-        time.sleep(1.5)
-        dev.set_control_mode(CONTROL_MODES.IMPEDANCE)
-        dev.set_impedance_gains(K=10, B=0.5)
+    error = property(get_motor_error_code, doc="temperature_degrees_C")
+    """Motor error code. 0 means no error.
+    
+    Codes:
+        0 : 'No Error',
+        1 : 'Over voltage fault',           # FAULT_CODE_OVER_VOLTAGE
+        2 : 'Under voltage fault',          # FAULT_CODE_UNDER_VOLTAGE  
+        3 : 'DRV fault',                    # FAULT_CODE_DRV
+        4 : 'Absolute over current fault',  # FAULT_CODE_ABS_OVER_CURRENT
+        5 : 'Over temp FET fault',          # FAULT_CODE_OVER_TEMP_FET
+        6 : 'Over temp motor fault',        # FAULT_CODE_OVER_TEMP_MOTOR
+        7 : 'Gate driver over voltage fault', # FAULT_CODE_GATE_DRIVER_OVER_VOLTAGE
+        8 : 'Gate driver under voltage fault', # FAULT_CODE_GATE_DRIVER_UNDER_VOLTAGE
+        9 : 'MCU under voltage fault',      # FAULT_CODE_MCU_UNDER_VOLTAGE
+        10: 'Booting from watchdog reset fault', # FAULT_CODE_BOOTING_FROM_WATCHDOG_RESET
+        11: 'Encoder SPI fault',            # FAULT_CODE_ENCODER_SPI
+        12: 'Encoder sincos below min amplitude fault', # FAULT_CODE_ENCODER_SINCOS_BELOW_MIN_AMPLITUDE
+        13: 'Encoder sincos above max amplitude fault', # FAULT_CODE_ENCODER_SINCOS_ABOVE_MAX_AMPLITUDE
+        14: 'Flash corruption fault',       # FAULT_CODE_FLASH_CORRUPTION
+        15: 'High offset current sensor 1 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_1
+        16: 'High offset current sensor 2 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_2
+        17: 'High offset current sensor 3 fault', # FAULT_CODE_HIGH_OFFSET_CURRENT_SENSOR_3
+        18: 'Unbalanced currents fault'     # FAULT_CODE_UNBALANCED_CURRENTS
+    """
 
-        print("Starting position step demo. Press ctrl+C to quit.")
+    # electrical variables
+    current_qaxis = property(get_current_qaxis_amps, set_motor_current_qaxis_amps, doc="current_qaxis_amps_current_only")
+    """Q-axis current in amps"""
 
-        loop = SoftRealtimeLoop(dt=0.01, report=True, fade=0)
-        for t in loop:
-            dev.update()
-            if t < 1.0:
-                dev.set_motor_position(0.0)
-            else:
-                dev.set_motor_position(10)
+    # output-side variables
+    position = property(get_output_angle_radians, set_output_angle_simple, doc="output_angle_radians_impedance_only")
+    """Output angle in rad"""
 
-            print(
-                "Actual: ",
-                round(dev.output_position, 3),
-                "Desired: ",
-                dev._command.position,
-            )
+    velocity = property (get_output_velocity_radians_per_second, set_output_velocity_radians_per_second, doc="output_velocity_radians_per_second")
+    """Output velocity in rad/s"""
 
-        del loop
+    acceleration = property(get_output_acceleration_radians_per_second_squared, doc="output_acceleration_radians_per_second_squared")
+    """Output acceleration in rad/s/s"""
+
+    torque = property(get_output_torque_newton_meters, set_output_torque_newton_meters, doc="output_torque_newton_meters")
+    """Output torque in Nm"""
+
+    # motor-side variables       
+    angle_motorside = property(get_motor_angle_radians, set_motor_angle_simple, doc="motor_angle_radians_impedance_only")
+    """Motor-side angle in rad"""
+    
+    velocity_motorside = property (get_motor_velocity_radians_per_second, set_motor_velocity_radians_per_second, doc="motor_velocity_radians_per_second")
+    """Motor-side velocity in rad/s"""
+
+    acceleration_motorside = property(get_motor_acceleration_radians_per_second_squared, doc="motor_acceleration_radians_per_second_squared")
+    """Motor-side acceleration in rad/s/s"""
+
+    torque_motorside = property(get_motor_torque_newton_meters, set_motor_torque_newton_meters, doc="motor_torque_newton_meters")
+    """Motor-side torque in Nm"""
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,12 @@ adafruit-circuitpython-bno055 = {version = "^5.4.13", markers = "sys_platform ==
 adafruit-circuitpython-lis3dh = {version = "^5.2.2", markers = "sys_platform == 'linux' and platform_machine == 'aarch64'"}
 
 pandas = "^2.2.3"
+python-can = {version = "^4.0.0", optional = true}
+
 [tool.poetry.extras]
 dephy = ["flexsea"]
 moteus = ["moteus", "moteus-pi3hat"]
+tmotor = ["python-can"]
 communication = ["smbus2"]
 messaging = ["grpcio", "grpcio-tools", "types-protobuf"]
 


### PR DESCRIPTION
Major Bug Fixes:
1. Fixed Buffer Function Call Errors:
   Error: Using undefined 'send_index' variable
   self.buffer_append_int32(buffer, np.int32(duty * 100000.0)) self.send_servo_message(controller_id|     (Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_DUTY'] << 8), buffer, send_index)
   Fixed: Correctly using len(buffer)
   self.buffer_append_int32(buffer, np.int32(duty * 100000.0)) self.send_servo_message(controller_id|(Servo_Params['CAN_PACKET_ID']['CAN_PACKET_SET_DUTY'] << 8), buffer, len(buffer))

2. Fixed Time Difference Calculation Error: 
   dt = self._last_update_time - now  # Error: Time difference calculation reversed
   dt = now - self._last_update_time  # Fixed: Correct time difference calculation

3. Fixed Conditional Check Error: 
    if (now - self._last_command_time) < 0.25 and ( (now - self._last_update_time) > 0.1):
    Missing null check for _last_command_time
    if self._last_command_time is not None and (now - self._last_command_time) < 0.25 and ( (now - self._last_update_time) > 0.1):
    Added null check to prevent TypeError

4. Fixed Position Unit Conversion: 
   self.buffer_append_int32(buffer, np.int32(pos * 1000000.0), send_index)  # Wrong conversion factor
   self.buffer_append_int32(buffer, np.int32(pos * 10000.0))  # Corrected conversion factor
