### PR TITLE
fixes #461: daq board fails silently

### DIFF
--- a/opensourceleg/sensors/adc.py
+++ b/opensourceleg/sensors/adc.py
@@ -160,7 +160,9 @@ class ADS131M0x(ADCBase):
             sleep(0.001)
             attempts += 1
             if attempts > MAX_ATTEMPTS:
-                raise RuntimeError("ADC not ready to read after 1 second.")
+                raise RuntimeError(
+                    "Couldn't connect to the ADC, please ensure that the device is connected and powered on."
+                )
 
         self._data = self._read_data_millivolts()
 

--- a/opensourceleg/sensors/adc.py
+++ b/opensourceleg/sensors/adc.py
@@ -152,9 +152,16 @@ class ADS131M0x(ADCBase):
     def update(self) -> None:
         """
         Update the ADC data by reading the latest voltage values in millivolts.
+        Attempts to read a maximum of 1000 times before throwing an error.
         """
+        MAX_ATTEMPTS = 1000
+        attempts = 0
         while not self._ready_to_read():
             sleep(0.001)
+            attempts += 1
+            if attempts > MAX_ATTEMPTS:
+                raise RuntimeError("ADC not ready to read after 1 second.")
+
         self._data = self._read_data_millivolts()
 
     def calibrate(self) -> None:


### PR DESCRIPTION
1. Add MAX_ATTEMPTS of 1000 to the ADS131M0x class' update method to prevent a while loop from running forever in case of a missing device or a problematic connection