### PR TITLE
updated uv install documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -114,6 +114,22 @@ This section is for those who want to contribute to opensourceleg or need to mod
    ```bash
    pip install uv
    ```
+   OR
+   ```bash
+   pip install uv --break-system-packages
+   ```
+   In your `.bashrc` script, add the following line:
+
+   ```bash
+   export PATH="$PATH:/home/username/.local/bin"
+   ```
+
+   Then reload your shell configuration:
+
+   ```bash
+   source ~/.bashrc
+   ```
+
    For other installation methods (including standalone installers), see the [UV installation guide](https://docs.astral.sh/uv/getting-started/installation/).
 
 - **Git**: Version control system, see [Git installation guide](https://git-scm.com/downloads)

--- a/uv.lock
+++ b/uv.lock
@@ -1027,7 +1027,7 @@ wheels = [
 
 [[package]]
 name = "opensourceleg"
-version = "3.3.0"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
This PR updates the documentation for installing uv and ensuring it is available in the system PATH. 
**Specifically**
* Added instructions using pip install uv with optional --break-system-packages for system-wide installs.
These changes hopefully make it easier for users to correctly set up uv and avoid common issues.