### PR TITLE
Making MSCL IMU import works across different mscl versions

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1027,7 +1027,7 @@ wheels = [
 
 [[package]]
 name = "opensourceleg"
-version = "3.4.0"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
The newer version of mscl does not create python bindings in "/usr/share/python3-mscl" instead it is stored in "dist-packages". 
**Specifically**
- Updated the import logic to first try the standard mscl import from disk-packages.
- Fallback to the legacy /usr/share/python3-mscl path only if the import fails.
- Added to the LOGGER.error message suggesting to check if disk-packages is in PYTHONPATH if the import fails even after the fallback.