### PR TITLE
docs: update MSCL package link and version in IMU docstring

### DIFF
--- a/opensourceleg/sensors/imu.py
+++ b/opensourceleg/sensors/imu.py
@@ -74,7 +74,6 @@ class LordMicrostrainIMU(IMUBase):
         Updating to a newer Raspberry Pi OS image with the rpi-v8 kernel
         or upgrading to MSCL v67.1.0 resolves the issue:
         https://github.com/LORD-MicroStrain/MSCL/releases/download/v67.1.0/MSCL_arm64_Python3.11_v67.1.0.deb
-        
     """
 
     def __init__(


### PR DESCRIPTION
#497 - Changed the MSCL pre-built package download link and version in the LordMicrostrainIMU class docstring to reference v67.1.0 instead of v65.0.0 for Raspbian.