### PR TITLE
docs: fix the display of the example of the home function of dephy.py

### DIFF
--- a/opensourceleg/actuators/dephy.py
+++ b/opensourceleg/actuators/dephy.py
@@ -355,6 +355,7 @@ class DephyActuator(Device, ActuatorBase):  # type: ignore[no-any-unimported]
                 Default is 0.001 rad/s.
             callback (Optional[Callable[[], None]]): Optional callback function to be called when homing completes.
                                                         The function should take no arguments and return None.
+
         Examples:
             >>> actuator = DephyActuator(port='/dev/ttyACM0')
             >>> actuator.start()


### PR DESCRIPTION
The example of the home function in the dephy.py is not displayed correctly.

Without the fix:
<img width="783" height="97" alt="image" src="https://github.com/user-attachments/assets/bab91899-e875-49e2-98a4-9327dfec8fe1" />

With the fix:
<img width="794" height="147" alt="screenshot_20251119_164640" src="https://github.com/user-attachments/assets/3026bffe-0bf4-41b3-81aa-b166f15b8f80" />

Link: https://neurobionics.github.io/opensourceleg/api/actuators/dephy/#opensourceleg.actuators.dephy.DephyActuator.home