### PR TITLE
Update MSCL documentation link to GitHub

### DIFF
--- a/docs/tutorials/sensors/reading_microstrain_imu_data.md
+++ b/docs/tutorials/sensors/reading_microstrain_imu_data.md
@@ -151,6 +151,6 @@ The LordMicrostrainIMU provides several useful properties:
 
 ## Additional Resources
 
-- [MSCL Documentation](https://lord-microstrain.github.io/MSCL/Documentation/MSCL%20API%20Documentation/index.html)
+- [MSCL Documentation](https://github.com/LORD-MicroStrain/MSCL_documentation/blob/main/latest/MSCL_API_Docs/index.html)
 
 If you have any questions or need further assistance, please post on the [Open Source Leg community forum](https://opensourceleg.discourse.group).


### PR DESCRIPTION
Under the "Additional Resources" section, MSCL Documentation link is not working

Update the MSCL documentation link from "https://lord-microstrain.github.io/MSCL/Documentation/MSCL%20API%20Documentation/index.html" to "https://github.com/LORD-MicroStrain/MSCL_documentation/blob/main/latest/MSCL_API_Docs/index.html"