### PR TITLE
Updated broken links in getting_started.md for actuators and sensors

### DIFF
--- a/docs/tutorials/robots/getting_started.md
+++ b/docs/tutorials/robots/getting_started.md
@@ -12,8 +12,8 @@ This guide introduces the `opensourceleg.robots` module and provides essential s
 ## Hardware Setup
 The hardware setup will be unique to each robot platform. If you are having trouble with your setup, please refer to the specific documentation regarding actuators and sensors below.
 
-- [Actuator Setup Guide](https://github.com/neurobionics/opensourceleg/blob/main/tutorials/actuators/getting_started.md)
-- [Sensor Setup Guide](https://github.com/neurobionics/opensourceleg/blob/main/tutorials/sensors/getting_started.md)
+- [Actuator Setup Guide](https://github.com/neurobionics/opensourceleg/blob/main/docs/tutorials/actuators/getting_started.md)
+- [Sensor Setup Guide](https://github.com/neurobionics/opensourceleg/blob/main/docs/tutorials/sensors/getting_started.md)
 
 ## Safety Guidelines
 


### PR DESCRIPTION
In docs/tutorials/robots/getting_started.md file, under the “Hardware Setup” section, the links for "Actuator Setup Guide" and "Sensor Setup Guide" are not working. To fix this issue, I have committed the two changes below

1. The link for “Actuator Setup Guide” is updated from “https://github.com/neurobionics/opensourceleg/blob/main/tutorials/actuators/getting_started.md” to “https://github.com/neurobionics/opensourceleg/blob/main/docs/tutorials/actuators/getting_started.md” 

2. The link for “Sensor Setup Guide” is updated from “https://github.com/neurobionics/opensourceleg/blob/main/tutorials/sensors/getting_started.md” to “https://github.com/neurobionics/opensourceleg/blob/main/docs/tutorials/sensors/getting_started.md”